### PR TITLE
Add Settings\LabId support - Fixes #64

### DIFF
--- a/LabBuilder/Samples/Sample_WS2012R2_DCandDHCPOnly.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_DCandDHCPOnly.xml
@@ -4,17 +4,17 @@
                   version="1.0">
   <description>Sample Windows Server 2012 R2 Lab Configuration DC and DHCP Only</description>
 
-  <settings domainname="LABBUILDER.COM"
-            email="daniel@LABBUILDER.COM"
-            labpath="c:\vm\LABBUILDER.COM"
-            vhdparentpath="c:\vm\LABBUILDER.COM\Virtual Hard Disk Templates"
+  <settings labid="LABBUILDER-DCANDDHCPONLY.COM"
+            domainname="LABBUILDER-DCANDDHCPONLY.COM"
+            email="admina@LABBUILDER-DCANDDHCPONLY.COM"
+            labpath="c:\vm\LABBUILDER-DCANDDHCPONLY.COM"
             dsclibrarypath="..\DSCLibrary\" />
 
   <resources>
   </resources>
   
   <switches>
-    <switch name="General Purpose External" type="External">
+    <switch name="External" type="External">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" />
         <adapter name="Management" macaddress="00155D010702" />
@@ -22,7 +22,7 @@
         <adapter name="LM" macaddress="00155D010704" />
       </adapters>
     </switch>
-    <switch name="General Purpose Internal" type="Internal" /> 
+    <switch name="Domain Internal" type="Internal" /> 
     <switch name="Domain Private Site A" type="Private" vlan="2" />
     <switch name="Domain Private Site B" type="Private" vlan="3" />
     <switch name="Domain Private Site C" type="Private" vlan="4" />
@@ -73,7 +73,7 @@
   </templates>
 
   <vms>
-    <vm name="LABBUILDER.COM SA-DC1"
+    <vm name="SA-DC1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DC1"
         usedifferencingbootdisk="Y">
@@ -85,8 +85,8 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
         <adapter name="Domain Private Site A"
                  switchname="Domain Private Site A">
           <ipv4 address="192.168.128.10"
@@ -101,7 +101,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DHCP1"
+    <vm name="SA-DHCP1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DHCP1"
         usedifferencingbootdisk="Y">
@@ -114,8 +114,8 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
         <adapter name="Domain Private Site A"
                  switchname="Domain Private Site A">
           <ipv4 address="192.168.128.16"

--- a/LabBuilder/Samples/Sample_WS2012R2_DomainClustering.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_DomainClustering.xml
@@ -4,17 +4,17 @@
                   version="1.0">
   <description>Sample Windows Server 2012 R2 Lab Configuration Domain Clustering</description>
 
-  <settings domainname="LABBUILDER.COM"
-            email="daniel@LABBUILDER.COM"
-            labpath="c:\vm\LABBUILDER.COM"
-            vhdparentpath="c:\vm\LABBUILDER.COM\Virtual Hard Disk Templates"
+  <settings labid="LABBUILDER-DOMAINCLUSTERING.COM"
+            domainname="LABBUILDER-DOMAINCLUSTERING.COM"
+            email="admin@LABBUILDER-DOMAINCLUSTERING.COM"
+            labpath="c:\vm\LABBUILDER-DOMAINCLUSTERING.COM"
             dsclibrarypath="..\DSCLibrary\" />
 
   <resources>
   </resources>
 
-  <switches managementvlan="97">
-    <switch name="General Purpose External" type="External">
+  <switches>
+    <switch name="External" type="External">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" />
         <adapter name="Management" macaddress="00155D010702" />
@@ -91,7 +91,7 @@
   </templates>
 
   <vms>
-    <vm name="LABBUILDER.COM SA-DC1"
+    <vm name="SA-DC1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DC1"
         usedifferencingbootdisk="Y">
@@ -117,7 +117,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DC2"
+    <vm name="SA-DC2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DC2"
         usedifferencingbootdisk="Y">
@@ -144,7 +144,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DHCP1"
+    <vm name="SA-DHCP1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DHCP1"
         usedifferencingbootdisk="Y">
@@ -272,7 +272,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-EDGE1"
+    <vm name="SA-EDGE1"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-EDGE1"
       usedifferencingbootdisk="Y">
@@ -296,12 +296,12 @@
                 subnetmask="64"
                 dnsserver="fd53:ccc5:895a:bc00::a,fd53:ccc5:895a:bc00::b"/>
         </adapter>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-ROOTCA"
+    <vm name="SA-ROOTCA"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-ROOTCA"
       usedifferencingbootdisk="Y">
@@ -342,7 +342,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FS1"
+    <vm name="SA-FS1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FS1"
         usedifferencingbootdisk="Y" >
@@ -404,7 +404,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-NLB1"
+    <vm name="SA-NLB1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-NLB1"
         usedifferencingbootdisk="Y" >
@@ -444,7 +444,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-NLB2"
+    <vm name="SA-NLB2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-NLB2"
         usedifferencingbootdisk="Y" >
@@ -484,7 +484,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FOC1"
+    <vm name="SA-FOC1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FOC1"
         usedifferencingbootdisk="Y" >
@@ -529,7 +529,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FOC2"
+    <vm name="SA-FOC2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FOC2"
         usedifferencingbootdisk="Y" >
@@ -574,7 +574,7 @@
       </adapters>
     </vm>
     
-    <vm name="LABBUILDER.COM SA-FOC3"
+    <vm name="SA-FOC3"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FOC3"
         usedifferencingbootdisk="Y" >
@@ -619,7 +619,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FOHV1"
+    <vm name="SA-FOHV1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FOHV1"
         memorystartupbytes="4GB"
@@ -665,7 +665,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FOHV2"
+    <vm name="SA-FOHV2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FOHV2"
         memorystartupbytes="4GB"
@@ -711,7 +711,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM DA-IT01"
+    <vm name="DA-IT01"
       template="Template Windows 10 Enterprise"
       computername="DA-IT01"
       usedifferencingbootdisk="Y">

--- a/LabBuilder/Samples/Sample_WS2012R2_DomainComplete.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_DomainComplete.xml
@@ -4,17 +4,17 @@
                   version="1.0">
   <description>Sample Windows Server 2012 R2 Lab Configuration Domain Complete</description>
 
-  <settings domainname="LABBUILDER.COM"
-            email="daniel@LABBUILDER.COM"
-            labpath="c:\vm\LABBUILDER.COM"
-            vhdparentpath="c:\vm\LABBUILDER.COM\Virtual Hard Disk Templates"
+  <settings labid="LABBUILDER-DOMAINCOMPLETE.COM"
+            domainname="LABBUILDER-DOMAINCOMPLETE.COM"
+            email="admin@LABBUILDER-DOMAINCOMPLETE.COM"
+            labpath="c:\vm\LABBUILDER-DOMAINCOMPLETE.COM"
             dsclibrarypath="..\DSCLibrary\" />
 
   <resources>
   </resources>
   
-  <switches managementvlan="98">
-    <switch name="General Purpose External" type="External">
+  <switches>
+    <switch name="External" type="External">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" />
         <adapter name="Management" macaddress="00155D010702" />
@@ -91,7 +91,7 @@
   </templates>
 
   <vms>
-    <vm name="LABBUILDER.COM SS-ROOTCA"
+    <vm name="SS-ROOTCA"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SS-ROOTCA"
         usedifferencingbootdisk="Y">
@@ -115,7 +115,7 @@
       </dsc>
     </vm>
 
-    <vm name="LABBUILDER.COM SS-INTERNET"
+    <vm name="SS-INTERNET"
         template="Template Windows Server 2012 R2 Datacenter Full"
         computername="SS-INTERNET"
         usedifferencingbootdisk="Y">
@@ -168,7 +168,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DC1"
+    <vm name="SA-DC1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DC1"
         usedifferencingbootdisk="Y">
@@ -194,7 +194,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DC2"
+    <vm name="SA-DC2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DC2"
         usedifferencingbootdisk="Y">
@@ -221,7 +221,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-RODC1"
+    <vm name="SA-RODC1"
     template="Template Windows Server 2012 R2 Datacenter CORE"
     computername="SA-RODC1"
     usedifferencingbootdisk="Y">
@@ -248,7 +248,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DHCP1"
+    <vm name="SA-DHCP1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-DHCP1"
         usedifferencingbootdisk="Y">
@@ -370,7 +370,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DHCP2"
+    <vm name="SA-DHCP2"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-DHCP2"
       usedifferencingbootdisk="Y">
@@ -412,7 +412,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-NPS"
+    <vm name="SA-NPS"
       template="Template Windows Server 2012 R2 Datacenter Full"
       computername="SA-NPS"
       usedifferencingbootdisk="Y">
@@ -439,7 +439,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-EDGE1"
+    <vm name="SA-EDGE1"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-EDGE1"
       usedifferencingbootdisk="Y">
@@ -473,7 +473,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-EDGE2"
+    <vm name="SA-EDGE2"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-EDGE2"
       usedifferencingbootdisk="Y">
@@ -507,7 +507,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-WDS"
+    <vm name="SA-WDS"
       template="Template Windows Server 2012 R2 Datacenter Full"
       computername="SA-WDS"
       usedifferencingbootdisk="Y" >
@@ -537,7 +537,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-WSUS"
+    <vm name="SA-WSUS"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-WSUS"
       usedifferencingbootdisk="Y" >
@@ -567,7 +567,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-SUBCA"
+    <vm name="SA-SUBCA"
       template="Template Windows Server 2012 R2 Datacenter CORE"
       computername="SA-SUBCA"
       usedifferencingbootdisk="Y">
@@ -603,7 +603,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FS1"
+    <vm name="SA-FS1"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FS1"
         usedifferencingbootdisk="Y" >
@@ -634,7 +634,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-FS2"
+    <vm name="SA-FS2"
         template="Template Windows Server 2012 R2 Datacenter CORE"
         computername="SA-FS2"
         usedifferencingbootdisk="Y" >
@@ -664,7 +664,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM DA-IT01"
+    <vm name="DA-IT01"
       template="Template Windows 10 Enterprise"
       computername="DA-IT01"
       usedifferencingbootdisk="Y">

--- a/LabBuilder/Samples/Sample_WS2012R2_Simple.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_Simple.xml
@@ -4,17 +4,17 @@
                   version="1.0">
   <description>Sample Windows Server 2012 R2 Lab Configuration Simple</description>
 
-  <settings domainname="LABBUILDER.COM"
-            email="daniel@LABBUILDER.COM"
-            labpath="c:\vm\LABBUILDER.COM"
-            vhdparentpath="c:\vm\LABBUILDER.COM\Virtual Hard Disk Templates"
+  <settings labid="LABBUILDER-SIMPLE.COM"
+            domainname="LABBUILDER-SIMPLE.COM"
+            email="admin@LABBUILDER-SIMPLE.COM"
+            labpath="c:\vm\LABBUILDER-SIMPLE.COM"
             dsclibrarypath="..\DSCLibrary\" />
 
   <resources>
   </resources>
 
   <switches>
-    <switch name="General Purpose External" type="External">
+    <switch name="External" type="External">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" />
         <adapter name="Management" macaddress="00155D010702" />
@@ -55,7 +55,7 @@
   </templates>
 
   <vms>   
-    <vm name="LABBUILDER.COM SS-DEFAULT"
+    <vm name="SS-DEFAULT"
         template="Template Windows Server 2012 R2 Datacenter FULL"
         computername="SS-DEFAULT"
         usedifferencingbootdisk="Y">
@@ -63,8 +63,8 @@
            configfile="STANDALONE_DEFAULT.DSC.ps1">
       </dsc>
       <adapters>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
         <adapter name="Domain Private Site A"
                  switchname="Domain Private Site A">
           <ipv4 address="192.168.10.2"

--- a/LabBuilder/Samples/Sample_WS2016TP4_DCandDHCPOnly.xml
+++ b/LabBuilder/Samples/Sample_WS2016TP4_DCandDHCPOnly.xml
@@ -4,17 +4,17 @@
                   version="1.0">
   <description>Sample Windows Server 2016 TP4 Lab Configuration DC and DHCP Only</description>
 
-  <settings domainname="LABBUILDER-WS2016TP4.COM"
-            email="daniel@LABBUILDER-WS2016TP4.COM"
+  <settings labid="LABBUILDER-WS2016TP4.COM"
+            domainname="LABBUILDER-WS2016TP4.COM"
+            email="admin@LABBUILDER-WS2016TP4.COM"
             labpath="c:\vm\LABBUILDER-WS2016TP4.COM"
-            vhdparentpath="c:\vm\LABBUILDER-WS2016TP4.COM\Virtual Hard Disk Templates"
             dsclibrarypath="..\DSCLibrary\" />
 
   <resources>
   </resources>
 
   <switches>
-    <switch name="General Purpose External" type="External">
+    <switch name="External" type="External">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" />
         <adapter name="Management" macaddress="00155D010702" />
@@ -90,7 +90,7 @@
   </templates>
 
   <vms>   
-    <vm name="LABBUILDER.COM SA-DC1"
+    <vm name="SA-DC1"
         template="Windows Server 2016 TP4 Datacenter FULL"
         computername="SA-DC1"
         usedifferencingbootdisk="Y">
@@ -102,8 +102,8 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
         <adapter name="Domain Private Site A"
                  switchname="Domain Private Site A">
           <ipv4 address="192.168.128.10"
@@ -118,7 +118,7 @@
       </adapters>
     </vm>
 
-    <vm name="LABBUILDER.COM SA-DHCP1"
+    <vm name="SA-DHCP1"
         template="Windows Server 2016 TP4 Datacenter CORE"
         computername="SA-DHCP1"
         usedifferencingbootdisk="Y">
@@ -131,8 +131,8 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="General Purpose External"
-                 switchname="General Purpose External" />
+        <adapter name="External"
+                 switchname="External" />
         <adapter name="Domain Private Site A"
                  switchname="Domain Private Site A">
           <ipv4 address="192.168.128.16"

--- a/LabBuilder/Tests/PesterTestConfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/Tests/PesterTestConfig/PesterTestConfig.OK.xml
@@ -4,7 +4,8 @@
                   version="1.0">
   <description>Configuration File Used with Pester Tests</description>
 
-  <settings domainname="PESTER.LOCAL"
+  <settings labid="TestLab"
+            domainname="PESTER.LOCAL"
             email="tester@pester.local"
             labpath="C:\Pester Lab"
             vhdparentpath="C:\Pester Lab\Virtual Hard Disk Templates"
@@ -18,7 +19,7 @@
   </resources>
 
   <switches>
-    <switch name="Pester Test External" type="External" >
+    <switch name="External" type="External" >
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" vlan="5"/>
         <adapter name="Management" macaddress="00155D010702" vlan="6"/>
@@ -26,10 +27,10 @@
         <adapter name="LM" macaddress="00155D010704" />
       </adapters>
     </switch>
-    <switch name="Pester Test Private Vlan" type="Private" vlan="2" />
-    <switch name="Pester Test Private" type="Private" />
-    <switch name="Pester Test Internal Vlan" type="Internal" vlan="3" />
-    <switch name="Pester Test Internal" type="Internal" />
+    <switch name="Private Vlan" type="Private" vlan="2" />
+    <switch name="Private" type="Private" />
+    <switch name="Internal Vlan" type="Internal" vlan="3" />
+    <switch name="Internal" type="Internal" />
   </switches>
 
   <templatevhds isopath="ISOFiles" 
@@ -175,7 +176,8 @@
         <datavhd vhd="DataDiskShared.vhdx" type="fixed" size="10GB" shared="Y" supportsr="Y" />
       </datavhds>
       <adapters>
-        <adapter name="Pester Test Private Vlan" switchname="Pester Test Private Vlan" macaddress="00155D010801" >
+        <adapter name="External" switchname="External" macaddress="00155D010801" />
+        <adapter name="Private Vlan" switchname="Private Vlan" macaddress="00155D010801" >
           <ipv4 address="192.168.16.1"
                 defaultgateway=""
                 subnetmask="24"
@@ -185,7 +187,7 @@
                 subnetmask="64"
                 dnsserver="fd53:ccc5:895a:0000::1"/>
         </adapter>
-        <adapter name="Pester Test Internal Vlan" switchname="Pester Test Internal Vlan" macaddress="00155D010802" >
+        <adapter name="Internal Vlan" switchname="Internal Vlan" macaddress="00155D010802" >
           <ipv4 address="192.168.16.2"
                 defaultgateway=""
                 subnetmask="24"
@@ -195,7 +197,7 @@
                 subnetmask="64"
                 dnsserver="fd53:ccc5:895a:0000::2"/>
         </adapter>
-        <adapter name="Pester Test Private" switchname="Pester Test Private" macaddress="00155D010803" vlan="3" >
+        <adapter name="Private" switchname="Private" macaddress="00155D010803" vlan="3" >
           <ipv4 address="192.168.16.3"
                 defaultgateway=""
                 subnetmask="24"
@@ -205,7 +207,7 @@
                 subnetmask="64"
                 dnsserver="fd53:ccc5:895a:0000::3"/>
         </adapter>
-        <adapter name="Pester Test Internal" switchname="Pester Test Internal" macaddress="00155D010804" vlan="4" >
+        <adapter name="Internal" switchname="Internal" macaddress="00155D010804" vlan="4" >
           <ipv4 address="192.168.16.4"
                 defaultgateway=""
                 subnetmask="24"

--- a/LabBuilder/Tests/PesterTestConfig/expectedcontent/ExpectedSwitches.json
+++ b/LabBuilder/Tests/PesterTestConfig/expectedcontent/ExpectedSwitches.json
@@ -19,35 +19,35 @@
                          }
                      ],
         "vlan":  null,
-        "name":  "Pester Test External",
+        "name":  "External",
         "natsubnetaddress":  null,
         "type":  "External"
     },
     {
         "adapters":  null,
         "vlan":  "2",
-        "name":  "Pester Test Private Vlan",
+        "name":  "TestLab Private Vlan",
         "natsubnetaddress":  null,
         "type":  "Private"
     },
     {
         "adapters":  null,
         "vlan":  null,
-        "name":  "Pester Test Private",
+        "name":  "TestLab Private",
         "natsubnetaddress":  null,
         "type":  "Private"
     },
     {
         "adapters":  null,
         "vlan":  "3",
-        "name":  "Pester Test Internal Vlan",
+        "name":  "TestLab Internal Vlan",
         "natsubnetaddress":  null,
         "type":  "Internal"
     },
     {
         "adapters":  null,
         "vlan":  null,
-        "name":  "Pester Test Internal",
+        "name":  "TestLab Internal",
         "natsubnetaddress":  null,
         "type":  "Internal"
     }

--- a/LabBuilder/Tests/PesterTestConfig/expectedcontent/ExpectedVMs.json
+++ b/LabBuilder/Tests/PesterTestConfig/expectedcontent/ExpectedVMs.json
@@ -1,11 +1,11 @@
 {
     "AdministratorPassword":  "Something",
     "IntegrationServices":  "Guest Service Interface,Heartbeat,Key-Value Pair Exchange,Shutdown,Time Synchronization,VSS",
-    "VMRootPath":  "C:\\Pester Lab\\PESTER01",
+    "VMRootPath":  "C:\\Pester Lab\\TestLab PESTER01",
     "Template":  "Pester Windows Server 2012 R2 Datacenter Full",
     "SetupComplete":  "",
     "ExposeVirtualizationExtensions":  "Y",
-    "Name":  "PESTER01",
+    "Name":  "TestLab PESTER01",
     "TimeZone":  "Pacific Standard Time",
     "OSType":  "Server",
     "DSCLogging":  false,
@@ -18,13 +18,26 @@
     "Adapters":  [
                      {
                          "IPv4":  {
+
+                                  },
+                         "Name":  "TestLab External",
+                         "SwitchName":  "External",
+                         "VLan":  "",
+                         "IPv6":  {
+
+                                  },
+                         "MACAddressSpoofing":  "Off",
+                         "MACAddress":  "00155D010801"
+                     },
+                     {
+                         "IPv4":  {
                                       "dnsserver":  "192.168.16.1",
                                       "subnetmask":  "24",
                                       "Address":  "192.168.16.1",
                                       "defaultgateway":  ""
                                   },
-                         "Name":  "Pester Test Private Vlan",
-                         "SwitchName":  "Pester Test Private Vlan",
+                         "Name":  "TestLab Private Vlan",
+                         "SwitchName":  "TestLab Private Vlan",
                          "VLan":  "2",
                          "IPv6":  {
                                       "dnsserver":  "fd53:ccc5:895a:0000::1",
@@ -42,8 +55,8 @@
                                       "Address":  "192.168.16.2",
                                       "defaultgateway":  ""
                                   },
-                         "Name":  "Pester Test Internal Vlan",
-                         "SwitchName":  "Pester Test Internal Vlan",
+                         "Name":  "TestLab Internal Vlan",
+                         "SwitchName":  "TestLab Internal Vlan",
                          "VLan":  "3",
                          "IPv6":  {
                                       "dnsserver":  "fd53:ccc5:895a:0000::2",
@@ -61,8 +74,8 @@
                                       "Address":  "192.168.16.3",
                                       "defaultgateway":  ""
                                   },
-                         "Name":  "Pester Test Private",
-                         "SwitchName":  "Pester Test Private",
+                         "Name":  "TestLab Private",
+                         "SwitchName":  "TestLab Private",
                          "VLan":  "3",
                          "IPv6":  {
                                       "dnsserver":  "fd53:ccc5:895a:0000::3",
@@ -80,8 +93,8 @@
                                       "Address":  "192.168.16.4",
                                       "defaultgateway":  ""
                                   },
-                         "Name":  "Pester Test Internal",
-                         "SwitchName":  "Pester Test Internal",
+                         "Name":  "TestLab Internal",
+                         "SwitchName":  "TestLab Internal",
                          "VLan":  "4",
                          "IPv6":  {
                                       "dnsserver":  "fd53:ccc5:895a:0000::4",
@@ -101,11 +114,11 @@
                    ],
     "DynamicMemoryEnabled":  "N",
     "MemoryStartupBytes":  2147483648,
-    "LabBuilderFilesPath":  "C:\\Pester Lab\\PESTER01\\LabBuilder Files",
+    "LabBuilderFilesPath":  "C:\\Pester Lab\\TestLab PESTER01\\LabBuilder Files",
     "DSCConfigName":  "STANDALONE_DEFAULT",
     "DataVHDs":  [
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskCopy.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskCopy.vhdx",
                          "type":  null,
                          "copyfolders":  "isofiles",
                          "partitionstyle":  null,
@@ -119,7 +132,7 @@
                          "sourcevhd":  "Intentionally Removed"
                      },
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskFixed.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskFixed.vhdx",
                          "type":  "fixed",
                          "copyfolders":  null,
                          "partitionstyle":  "MBR",
@@ -133,7 +146,7 @@
                          "sourcevhd":  "Intentionally Removed"
                      },
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskDynamic.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskDynamic.vhdx",
                          "type":  "dynamic",
                          "copyfolders":  null,
                          "partitionstyle":  "GPT",
@@ -147,7 +160,7 @@
                          "sourcevhd":  "Intentionally Removed"
                      },
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskDifferencing.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskDifferencing.vhdx",
                          "type":  "differencing",
                          "copyfolders":  null,
                          "partitionstyle":  null,
@@ -161,7 +174,7 @@
                          "sourcevhd":  "Intentionally Removed"
                      },
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskMove.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskMove.vhdx",
                          "type":  null,
                          "copyfolders":  null,
                          "partitionstyle":  null,
@@ -175,7 +188,7 @@
                          "sourcevhd":  "Intentionally Removed"
                      },
                      {
-                         "vhd":  "C:\\Pester Lab\\PESTER01\\Virtual Hard Disks\\DataDiskShared.vhdx",
+                         "vhd":  "C:\\Pester Lab\\TestLab PESTER01\\Virtual Hard Disks\\DataDiskShared.vhdx",
                          "type":  "fixed",
                          "copyfolders":  null,
                          "partitionstyle":  null,

--- a/LabBuilder/Tests/Unit/LabBuilder.tests.ps1
+++ b/LabBuilder/Tests/Unit/LabBuilder.tests.ps1
@@ -123,8 +123,9 @@ InModuleScope LabBuilder {
 #endregion    
 
 
-
+#region LabSwitchFunctions
     Describe 'Get-LabSwitch' {
+
         Context 'Configuration passed with switch missing Switch Name.' {
             It 'Throws a SwitchNameIsEmptyError Exception' {
                 $Config = Get-LabConfiguration -Path $Global:TestConfigOKPath
@@ -147,7 +148,7 @@ InModuleScope LabBuilder {
                     errorId = 'UnknownSwitchTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.UnknownSwitchTypeError `
-                        -f '','Pester Test External')
+                        -f '',"$($Config.labbuilderconfig.settings.labid) External")
                 }
                 $Exception = GetException @ExceptionParameters
 
@@ -162,7 +163,7 @@ InModuleScope LabBuilder {
                     errorId = 'UnknownSwitchTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.UnknownSwitchTypeError `
-                        -f 'BadType','Pester Test External')
+                        -f 'BadType',"$($Config.labbuilderconfig.settings.labid) External")
                 }
                 $Exception = GetException @ExceptionParameters
 
@@ -177,7 +178,7 @@ InModuleScope LabBuilder {
                     errorId = 'AdapterSpecifiedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.AdapterSpecifiedError `
-                        -f 'Private','Pester Test External')
+                        -f 'Private',"$($Config.labbuilderconfig.settings.labid) External")
                 }
                 $Exception = GetException @ExceptionParameters
 
@@ -363,9 +364,10 @@ InModuleScope LabBuilder {
             }
         }
     }
+#endregion
 
 
-
+#region LabVMTemplateVHDFunctions
     Describe 'Get-LabVMTemplateVHD' {
 
         Context 'Configuration passed with rooted ISO Root Path that does not exist' {
@@ -676,9 +678,10 @@ InModuleScope LabBuilder {
             }            
         }
     }
+#endregion
 
 
-
+#region LabVMTemplateFunctions
     Describe 'Get-LabVMTemplate' {
 
         Mock Get-VM
@@ -910,18 +913,23 @@ InModuleScope LabBuilder {
             }
         }
     }
+#endregion
 
 
-
+#region LabVMFunctions
     Describe 'Get-LabVM' {
 
         #region mocks
         Mock Get-VM
         #endregion
 
+        # Figure out the TestVMName (saves typing later on)
+        $Config = Get-LabConfiguration -Path $Global:TestConfigOKPath        
+        $TestVMName = "$($Config.labbuilderconfig.settings.labid) $($Config.labbuilderconfig.vms.vm.name)"
+
         Context 'Configuration passed with VM missing VM Name.' {
             It 'Throw VMNameError Exception' {
-                $Config = Get-LabConfiguration -Path $Global:TestConfigOKPath
+                $Config = Get-LabConfiguration -Path $Global:TestConfigOKPath        
                 $Config.labbuilderconfig.vms.vm.RemoveAttribute('name')
                 [Array]$Switches = Get-LabSwitch -Config $Config
                 [array]$Templates = Get-LabVMTemplate -Config $Config
@@ -944,7 +952,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMTemplateNameEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNameEmptyError `
-                        -f $Config.labbuilderconfig.vms.vm.name)
+                        -f $TestVMName)
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -960,7 +968,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMTemplateNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNotFoundError `
-                        -f $Config.labbuilderconfig.vms.vm.name,'BadTemplate')
+                        -f $TestVMName,'BadTemplate')
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -976,7 +984,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMAdapterNameError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMAdapterNameError `
-                        -f $Config.labbuilderconfig.vms.vm.name)
+                        -f $TestVMName)
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -992,7 +1000,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMAdapterSwitchNameError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMAdapterSwitchNameError `
-                        -f $Config.labbuilderconfig.vms.vm.name,$Config.labbuilderconfig.vms.vm.adapters.adapter[0].name)
+                        -f $TestVMName,$($Config.labbuilderconfig.vms.vm.adapters.adapter[0].name))
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1008,7 +1016,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskVHDEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskVHDEmptyError `
-                        -f $Config.labbuilderconfig.vms.vm.name)
+                        -f $TestVMName)
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1024,7 +1032,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskParentVHDNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskParentVHDNotFoundError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"c:\ThisFileDoesntExist.vhdx")
+                        -f $TestVMName,"c:\ThisFileDoesntExist.vhdx")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1040,7 +1048,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskSourceVHDNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSourceVHDNotFoundError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"c:\ThisFileDoesntExist.vhdx")
+                        -f $TestVMName,"c:\ThisFileDoesntExist.vhdx")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1056,7 +1064,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskParentVHDMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskParentVHDMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name)
+                        -f $TestVMName)
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1072,7 +1080,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskSharedDifferencingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSharedDifferencingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[3].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[3].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1088,7 +1096,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskUnknownTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskUnknownTypeError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'badtype')
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'badtype')
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1104,7 +1112,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskSupportPRError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSupportPRError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1120,7 +1128,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskPartitionStyleError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1136,7 +1144,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskFileSystemError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskFileSystemError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1152,7 +1160,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskPartitionStyleMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1168,7 +1176,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskFileSystemMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskFileSystemMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1185,7 +1193,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskPartitionStyleMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[2].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[2].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1201,7 +1209,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskCopyFolderMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCopyFolderMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)",'c:\doesnotexist')
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)",'c:\doesnotexist')
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1217,7 +1225,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1233,7 +1241,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1249,7 +1257,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1265,7 +1273,7 @@ InModuleScope LabBuilder {
                     errorId = 'VMDataDiskSourceVHDIfMoveError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSourceVHDIfMoveError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[4].vhd)")
+                        -f $TestVMName,"$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Config.labbuilderconfig.vms.vm.datavhds.datavhd[4].vhd)")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1281,7 +1289,7 @@ InModuleScope LabBuilder {
                     errorId = 'UnattendFileMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.UnattendFileMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$Global:TestConfigPath\ThisFileDoesntExist.xml")
+                        -f $TestVMName,"$Global:TestConfigPath\ThisFileDoesntExist.xml")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1297,7 +1305,7 @@ InModuleScope LabBuilder {
                     errorId = 'SetupCompleteFileMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.SetupCompleteFileMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$Global:TestConfigPath\ThisFileDoesntExist.ps1")
+                        -f $TestVMName,"$Global:TestConfigPath\ThisFileDoesntExist.ps1")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1313,7 +1321,7 @@ InModuleScope LabBuilder {
                     errorId = 'SetupCompleteFileBadTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.SetupCompleteFileBadTypeError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$Global:TestConfigPath\ThisFileDoesntExist.abc")
+                        -f $TestVMName,"$Global:TestConfigPath\ThisFileDoesntExist.abc")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1329,7 +1337,7 @@ InModuleScope LabBuilder {
                     errorId = 'DSCConfigFileMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.DSCConfigFileMissingError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$Global:TestConfigPath\DSCLibrary\ThisFileDoesntExist.ps1")
+                        -f $TestVMName,"$Global:TestConfigPath\DSCLibrary\ThisFileDoesntExist.ps1")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1345,7 +1353,7 @@ InModuleScope LabBuilder {
                     errorId = 'DSCConfigFileBadTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.DSCConfigFileBadTypeError `
-                        -f $Config.labbuilderconfig.vms.vm.name,"$Global:TestConfigPath\DSCLibrary\FileWithBadType.xyz")
+                        -f $TestVMName,"$Global:TestConfigPath\DSCLibrary\FileWithBadType.xyz")
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1361,7 +1369,7 @@ InModuleScope LabBuilder {
                     errorId = 'DSCConfigNameIsEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.DSCConfigNameIsEmptyError `
-                        -f $Config.labbuilderconfig.vms.vm.name)
+                        -f $TestVMName)
                 }
                 $Exception = GetException @ExceptionParameters
                 { Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
@@ -1384,7 +1392,7 @@ InModuleScope LabBuilder {
             [Array]$Templates = Get-LabVMTemplate -Config $Config
             [Array]$VMs = Get-LabVM -Config $Config -VMTemplates $Templates -Switches $Switches
             It 'Returns Template Object containing VHD with correct rooted path' {
-                $VMs[0].DataVhds[0].vhd | Should Be "$($Config.labbuilderconfig.settings.labpath)\$($Config.labbuilderconfig.vms.vm.name)\Virtual Hard Disks\DataDisk.vhdx"
+                $VMs[0].DataVhds[0].vhd | Should Be "$($Config.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\DataDisk.vhdx"
             }
         }
         Context 'Valid configuration is passed with VM Data Disk with rooted Parent VHD path.' {
@@ -1563,7 +1571,7 @@ InModuleScope LabBuilder {
 
     Describe 'Remove-LabVM' {
         #region Mocks
-        Mock Get-VM -MockWith { [PSObject]@{ Name = 'PESTER01'; State = 'Running'; } }
+        Mock Get-VM -MockWith { [PSObject]@{ Name = 'TestLab PESTER01'; State = 'Running'; } }
         Mock Stop-VM
         Mock WaitVMOff -MockWith { Return $True }
         Mock Get-VMHardDiskDrive
@@ -1632,9 +1640,10 @@ InModuleScope LabBuilder {
 
     Describe 'Disconnect-LabVM' -Tags 'Incomplete'  {
     }
+#endregion
 
 
-
+#region LabFunctions
     Describe 'Install-Lab' -Tags 'Incomplete'  {
     }
 
@@ -1642,4 +1651,5 @@ InModuleScope LabBuilder {
 
     Describe 'Uninstall-Lab' -Tags 'Incomplete'  {
     }
+#endregion    
 }

--- a/LabBuilder/Tests/Unit/lib/switch.tests.ps1
+++ b/LabBuilder/Tests/Unit/lib/switch.tests.ps1
@@ -1,0 +1,50 @@
+$Global:ModuleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)))
+
+Set-Location $ModuleRoot
+if (Get-Module LabBuilder -All)
+{
+    Get-Module LabBuilder -All | Remove-Module
+}
+
+Import-Module "$Global:ModuleRoot\LabBuilder.psd1" -Force -DisableNameChecking
+$Global:TestConfigPath = "$Global:ModuleRoot\Tests\PesterTestConfig"
+$Global:TestConfigOKPath = "$Global:TestConfigPath\PesterTestConfig.OK.xml"
+$Global:ArtifactPath = "$Global:ModuleRoot\Artifacts"
+$Global:ExpectedContentPath = "$Global:TestConfigPath\ExpectedContent"
+$null = New-Item -Path "$Global:ArtifactPath" -ItemType Directory -Force -ErrorAction SilentlyContinue
+
+InModuleScope LabBuilder {
+<#
+.SYNOPSIS
+   Helper function that just creates an exception record for testing.
+#>
+    function GetException
+    {
+        [CmdLetBinding()]
+        param
+        (
+            [Parameter(Mandatory)]
+            [String] $errorId,
+
+            [Parameter(Mandatory)]
+            [System.Management.Automation.ErrorCategory] $errorCategory,
+
+            [Parameter(Mandatory)]
+            [String] $errorMessage,
+            
+            [Switch]
+            $terminate
+        )
+
+        $exception = New-Object -TypeName System.Exception `
+            -ArgumentList $errorMessage
+        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+            -ArgumentList $exception, $errorId, $errorCategory, $null
+        return $errorRecord
+    }
+    
+    
+    
+    Describe 'IsAdmin' -Tag 'Incomplete' {
+    }
+}

--- a/LabBuilder/lib/dsc.ps1
+++ b/LabBuilder/lib/dsc.ps1
@@ -408,8 +408,8 @@ function SetDSCStartFile {
 
     # Relabel the Network Adapters so that they match what the DSC Networking config will use
     # This is because unfortunately the Hyper-V Device Naming feature doesn't work.
-    [String] $ManagementSwitchName = `
-        ('LabBuilder Management {0}' -f $Config.labbuilderconfig.name)
+    [String] $ManagementSwitchName = GetManagementSwitchName `
+        -Config $Config
     $Adapters = @(($VM.Adapters).Name)
     $Adapters += @($ManagementSwitchName)
 

--- a/LabBuilder/lib/switch.ps1
+++ b/LabBuilder/lib/switch.ps1
@@ -1,0 +1,35 @@
+<#
+.SYNOPSIS
+   Returns the name of the Management Switch to use for this lab.
+.DESCRIPTION
+   Each lab has a unique private management switch created for it.
+   All Virtual Machines in the Lab are connected to the switch.
+   This function returns the name of this swtich for the provided
+   lab configuration.
+.PARAMETER Configuration
+   Contains the Lab Builder configuration object that was loaded by the Get-LabConfiguration
+   object.
+.EXAMPLE
+   $Config = Get-LabConfiguration -Path c:\mylab\config.xml
+   $ManagementSwtich = GetManagementSwitchName -Config $Config
+   Returns the Management Switch for the Lab c:\mylab\config.xml.
+.OUTPUTS
+   A management switch name.
+#>
+function GetManagementSwitchName {
+    [CmdLetBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [XML] $Config
+    )
+
+    [String] $LabId = $Config.labbuilderconfig.settings.labid 
+    if (-not $LabId)
+    {
+        $LabId = $Config.labbuilderconfig.name
+    }
+    $ManagementSwitchName = ('{0} Lab Management' `
+        -f $LabId)
+
+    return $ManagementSwitchName
+} # GetManagementSwitchName

--- a/LabBuilder/lib/vm.ps1
+++ b/LabBuilder/lib/vm.ps1
@@ -879,8 +879,8 @@ function GetVMManagementIPAddress {
         [Parameter(Mandatory)]
         [System.Collections.Hashtable] $VM
     )
-    [String] $ManagementSwitchName = ('LabBuilder Management {0}' `
-        -f $Config.labbuilderconfig.name)
+    [String] $ManagementSwitchName = GetManagementSwitchName `
+        -Config $Config
     [String] $IPAddress = (Get-VMNetworkAdapter -VMName $VM.Name).`
         Where({$_.SwitchName -eq $ManagementSwitchName}).`
         IPAddresses.Where({$_.Contains('.')})

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Summary
 -------
 This module will build a multiple machine Hyper-V Lab environment from an XML configuration file and other optional installation scripts.
 
+
 Introduction
 ------------
 While studying for some of my Microsoft certifications I had a need to quickly and easily spin up various Hyper-V Lab environments so that I could experiment with and learn the technologies involved.
@@ -40,6 +41,7 @@ The general goals of this project are:
 + Allow GUI based tools to be easily created to create Lab configurations.
 + Enable new Lab VM machine types to be configured by supplying different DSC library resources.
 
+
 Basic Usage Guide
 -----------------
 The use of this module is fairly simple from a process standpoint with the bulk of the work creating a Lab going into the creation of the configuration XML that defines it. But if there is a Lab configuration already available that fits your needs then there is almost nothing to do.
@@ -66,6 +68,7 @@ Install-Lab -Path 'c:\MyLab\Configuration.xml'
 ```
 
 This will create a new Lab using the c:\MyLab\Configuration.xml file.
+
 
 Requirements
 ------------
@@ -153,11 +156,6 @@ Versions
 ### 0.1.0.0
 * Initial Release.
 
-Functions
----------
-
-Example Usage
--------------
 
 Links
 -----

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Versions
 * Fixed bug setting TrustedHosts when connecting to Lab VM.
 * Added code to revert TrustedHosts when disconnecting from Lab VM. 
 * All non-exported supporting functions moved into separate support libraries.
+* Add support for LabId setting that gets prepended to Lab resources.
 
 ### 0.4.0.0
 * Some secondary non-exported functions moved into separate support libraries.


### PR DESCRIPTION
Adding a LabId setting to a configuration will cause Switch names, Adapter names and VM names to be prepended with the LabId.