### PR TITLE
External switch no longer sets another Hyper-V Adapter as it's NetAdapterName

### DIFF
--- a/LabBuilder/LabBuilder.psm1
+++ b/LabBuilder/LabBuilder.psm1
@@ -619,7 +619,7 @@ function Initialize-LabSwitch {
                         -Name $SwitchName `
                         -NetAdapterName (`
                             Get-NetAdapter | `
-                            Where-Object { $_.Status -eq 'Up' } | `
+                            Where-Object { $_.Status -eq 'Up' -and $_.InterfaceDescription -notlike "Hyper-V Virtual*" } | `
                             Select-Object -First 1 -ExpandProperty Name `
                             )
                     if ($VMSwitch.Adapters)


### PR DESCRIPTION
Fixes an issue where you will get an error if (Get-NetAdapter | Select-Object -First 1) returns another Hyper-V adapter instead of a physical netadapter.