### PR TITLE
Add DSC Domain in Existing Forest - Fixes #142

### DIFF
--- a/LabBuilder/DSCLibrary/DC_FORESTPRIMARY.DSC.ps1
+++ b/LabBuilder/DSCLibrary/DC_FORESTPRIMARY.DSC.ps1
@@ -4,7 +4,7 @@ DSC Template Configuration File For use by LabBuilder
     DC_FORESTPRIMARY
 .Desription
     Builds a Domain Controller as the first DC in a forest with the name of the Domain Name parameter passed.
-.Parameters:          
+.Parameters:
     DomainName = "LABBUILDER.COM"
     DomainAdminPassword = "P@ssword!1"
 ###################################################################################################>
@@ -30,17 +30,17 @@ Configuration DC_FORESTPRIMARY
         } 
 
         WindowsFeature DNSInstall 
-        { 
-            Ensure = "Present" 
-            Name = "DNS" 
-        } 
+        {
+            Ensure = "Present"
+            Name = "DNS"
+        }
 
-        WindowsFeature ADDSInstall 
-        { 
-            Ensure = "Present" 
-            Name = "AD-Domain-Services" 
-            DependsOn = "[WindowsFeature]DNSInstall" 
-        } 
+        WindowsFeature ADDSInstall
+        {
+            Ensure = "Present"
+            Name = "AD-Domain-Services"
+            DependsOn = "[WindowsFeature]DNSInstall"
+        }
         
         WindowsFeature RSAT-AD-PowerShellInstall
         {
@@ -49,22 +49,22 @@ Configuration DC_FORESTPRIMARY
             DependsOn = "[WindowsFeature]ADDSInstall"
         }
 
-        xADDomain PrimaryDC 
-        { 
+        xADDomain PrimaryDC
+        {
             DomainName = $Node.DomainName 
-            DomainAdministratorCredential = $DomainAdminCredential 
-            SafemodeAdministratorPassword = $LocalAdminCredential 
-            DependsOn = "[WindowsFeature]ADDSInstall" 
-        } 
+            DomainAdministratorCredential = $DomainAdminCredential
+            SafemodeAdministratorPassword = $LocalAdminCredential
+            DependsOn = "[WindowsFeature]ADDSInstall"
+        }
 
         xWaitForADDomain DscForestWait 
-        { 
+        {
             DomainName = $Node.DomainName 
-            DomainUserCredential = $DomainAdminCredential 
-            RetryCount = 20 
-            RetryIntervalSec = 30 
-            DependsOn = "[xADDomain]PrimaryDC" 
-        } 
+            DomainUserCredential = $DomainAdminCredential
+            RetryCount = 20
+            RetryIntervalSec = 30
+            DependsOn = "[xADDomain]PrimaryDC"
+        }
         
         # Enable AD Recycle bin
         xADRecycleBin RecycleBin

--- a/LabBuilder/Samples/Sample_WS2012R2_DCandDHCPOnly.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_DCandDHCPOnly.xml
@@ -112,7 +112,7 @@
            configfile="MEMBER_DHCP.DSC.ps1">
         <parameters>
           DomainName = "LABBUILDER.COM"
-		  DCname = "SA-DC1"
+          DCname = "SA-DC1"
           DomainAdminPassword = "P@ssword!1"
           PSDscAllowDomainUser = $True
         </parameters>

--- a/LabBuilder/Samples/Sample_WS2012R2_DomainClustering.xml
+++ b/LabBuilder/Samples/Sample_WS2012R2_DomainClustering.xml
@@ -133,7 +133,7 @@
            configfile="DC_SECONDARY.DSC.ps1">
         <parameters>
           DomainName = "LABBUILDER.COM"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           DomainAdminPassword = "P@ssword!1"
           PSDscAllowDomainUser = $True
         </parameters>
@@ -162,7 +162,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
           Scopes = @(
               @{ Name = 'Site A Primary';
@@ -291,7 +291,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
         </parameters>
       </dsc>
@@ -367,7 +367,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
           TargetName = 'sa-foc-target'
           VirtualDisks =  @(
@@ -426,7 +426,7 @@
            logging="Y">
         <parameters>
           DomainName = "LABBUILDER.COM"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           DomainAdminPassword = "P@ssword!1"
           PSDscAllowDomainUser = $True
         </parameters>
@@ -467,7 +467,7 @@
            logging="Y">
         <parameters>
           DomainName = "LABBUILDER.COM"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           DomainAdminPassword = "P@ssword!1"
           PSDscAllowDomainUser = $True
         </parameters>
@@ -509,7 +509,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
           ServerTargetName = 'sa-fs1-sa-foc-target-target'
           TargetPortalAddress = '192.168.129.24'
@@ -555,7 +555,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
           ServerTargetName = 'sa-fs1-sa-foc-target-target'
           TargetPortalAddress = '192.168.129.24'
@@ -601,7 +601,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
           ServerTargetName = 'sa-fs1-sa-foc-target-target'
           TargetPortalAddress = '192.168.129.24'
@@ -650,7 +650,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
         </parameters>
       </dsc>
@@ -697,7 +697,7 @@
         <parameters>
           DomainName = "LABBUILDER.COM"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "SA-DC1"
+          DCName = "SA-DC1"
           PSDscAllowDomainUser = $True
         </parameters>
       </dsc>

--- a/LabBuilder/samples/Sample_WS2012R2_MultiForest.xml
+++ b/LabBuilder/samples/Sample_WS2012R2_MultiForest.xml
@@ -7,6 +7,7 @@
   Sample Windows Server 2012 R2 Lab Configuration containing two forests:
    - ALPHA.LOCAL
    - BRAVO.LOCAL
+  Each forest contains a child domain DEV.*.LOCAL.
   Each forest is on an isolated subnet and contains a DC server, DHCP server and an Edge Server.
   The edge servers are also on a shared subnet (Domain Internal) enabling routing between the isolated subnets (Domain Private Alpha/Bravo).
   A forest trust is not established between the forests.
@@ -95,8 +96,6 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="External"
-                 switchname="External" />
         <adapter name="Domain Private Alpha"
                  switchname="Domain Private Alpha">
           <ipv4 address="192.168.128.10"
@@ -111,6 +110,33 @@
       </adapters>
     </vm>
 
+    <vm name="ALPHA-DC2"
+        template="Template Windows Server 2012 R2 Datacenter Full"
+        computername="ALPHA-DC2">
+      <dsc configname="DC_FORESTDOMAIN"
+           configfile="DC_FORESTDOMAIN.DSC.ps1">
+        <parameters>
+          ParentDomainName = "ALPHA.LOCAL"
+          DomainName = "DEV"
+          DomainAdminPassword = "P@ssword!1"
+          PSDscAllowDomainUser = $True
+        </parameters>
+      </dsc>
+      <adapters>
+        <adapter name="Domain Private Alpha"
+                 switchname="Domain Private Alpha">
+          <ipv4 address="192.168.128.11"
+                defaultgateway="192.168.128.19"
+                subnetmask="24"
+                dnsserver="192.168.128.11,192.168.128.10"/>
+          <ipv6 address="fd53:ccc5:895a:bc00::b"
+                defaultgateway="fd53:ccc5:895a:bc00::13"
+                subnetmask="64"
+                dnsserver="fd53:ccc5:895a:bc00::b,fd53:ccc5:895a:bc00::a"/>
+        </adapter>
+      </adapters>
+    </vm>
+
     <vm name="ALPHA-DHCP1"
         template="Template Windows Server 2012 R2 Datacenter Full"
         computername="ALPHA-DHCP1"
@@ -120,7 +146,7 @@
         <parameters>
           DomainName = "ALPHA.LOCAL"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "ALPHA-DC1"
+          DCName = "ALPHA-DC1"
           PSDscAllowDomainUser = $True
           Scopes = @(
               @{ Name = 'Alpha Primary';
@@ -135,6 +161,12 @@
                  ScopeID = '192.168.128.0';
                  ClientMACAddress = '000000000000';
                  IPAddress = '192.168.128.10';
+                 AddressFamily = 'IPv4'
+              },
+              @{ Name = 'ALPHA-DC2';
+                 ScopeID = '192.168.128.0';
+                 ClientMACAddress = '000000000001';
+                 IPAddress = '192.168.128.11';
                  AddressFamily = 'IPv4'
               },
               @{ Name = 'ALPHA-DHCP1';
@@ -183,7 +215,7 @@
         <parameters>
           DomainName = "ALPHA.LOCAL"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "ALPHA-DC1"
+          DCName = "ALPHA-DC1"
           PSDscAllowDomainUser = $True
         </parameters>
       </dsc>
@@ -226,8 +258,6 @@
         </parameters>
       </dsc>
       <adapters>
-        <adapter name="External"
-                 switchname="External" />
         <adapter name="Domain Private Bravo"
                  switchname="Domain Private Bravo">
           <ipv4 address="192.168.130.10"
@@ -242,6 +272,33 @@
       </adapters>
     </vm>
 
+    <vm name="BRAVO-DC2"
+        template="Template Windows Server 2012 R2 Datacenter Full"
+        computername="BRAVO-DC2">
+      <dsc configname="DC_FORESTDOMAIN"
+           configfile="DC_FORESTDOMAIN.DSC.ps1">
+        <parameters>
+          ParentDomainName = "BRAVO.LOCAL"
+          DomainName = "DEV"
+          DomainAdminPassword = "P@ssword!1"
+          PSDscAllowDomainUser = $True
+        </parameters>
+      </dsc>
+      <adapters>
+        <adapter name="Domain Private Bravo"
+                 switchname="Domain Private Bravo">
+          <ipv4 address="192.168.130.11"
+                defaultgateway="192.168.130.19"
+                subnetmask="24"
+                dnsserver="192.168.130.11,192.168.130.10"/>
+          <ipv6 address="fd53:ccc5:895c:bc00::b"
+                defaultgateway="fd53:ccc5:895c:bc00::13"
+                subnetmask="64"
+                dnsserver="fd53:ccc5:895c:bc00::b,fd53:ccc5:895c:bc00::a"/>
+        </adapter>
+      </adapters>
+    </vm>
+
     <vm name="BRAVO-DHCP1"
         template="Template Windows Server 2012 R2 Datacenter Full"
         computername="BRAVO-DHCP1"
@@ -251,7 +308,7 @@
         <parameters>
           DomainName = "BRAVO.LOCAL"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "BRAVO-DC1"
+          DCName = "BRAVO-DC1"
           PSDscAllowDomainUser = $True
           Scopes = @(
               @{ Name = 'Bravo Primary';
@@ -266,6 +323,12 @@
                  ScopeID = '192.168.130.0';
                  ClientMACAddress = '000000000000';
                  IPAddress = '192.168.130.10';
+                 AddressFamily = 'IPv4'
+              },
+              @{ Name = 'BRAVO-DC2';
+                 ScopeID = '192.168.130.0';
+                 ClientMACAddress = '000000000001';
+                 IPAddress = '192.168.130.11';
                  AddressFamily = 'IPv4'
               },
               @{ Name = 'BRAVO-DHCP1';
@@ -314,7 +377,7 @@
         <parameters>
           DomainName = "BRAVO.LOCAL"
           DomainAdminPassword = "P@ssword!1"
-		  DCName = "BRAVO-DC1"
+          DCName = "BRAVO-DC1"
           PSDscAllowDomainUser = $True
         </parameters>
       </dsc>

--- a/README.md
+++ b/README.md
@@ -491,9 +491,11 @@ None
 
 Versions
 ========
-### 0.6.1.0
+### Unreleased
 * Initialize-LabSwitch: External switch correctly sets Adapter Name.
 * IsAdmin: Function removed because was not useful.
+* dsclibrary\DC_FORESTDOMAIN.DSC: New DSC Library config for creating child domains in an existing forest.
+* Samples\Sample_WS2012R2_MultiForest.xml: Added child domains.
 
 ### 0.6.0.0
 * New-Lab: Function added for creating a new Lab configuration file and basic folder structure.


### PR DESCRIPTION
* dsclibrary\DC_FORESTDOMAIN.DSC: New DSC Library config for creating child domains in an existing forest.
* Samples\Sample_WS2012R2_MultiForest.xml: Added child domains.