### PR TITLE
 Fix DSC error occuring when a blank DNS Server specified - Fixes #153

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -1,3 +1,7 @@
+### 0.7.1.0
+* GetDSCNetworkingConfig: Fix DSC error occuring when a blank DNS Server address or Default Gateway address is set on an Adapter.
+* InitializeVhd: Prevent unnecessary results of disk partitioning and volume creation to console.
+
 ### 0.7.0.0
 * Initialize-LabSwitch: External switch correctly sets Adapter Name.
 * IsAdmin: Function removed because was not useful.

--- a/LabBuilder/lib/dsc.ps1
+++ b/LabBuilder/lib/dsc.ps1
@@ -970,7 +970,7 @@ Configuration Networking {
         $AdapterCount++
         if ($Adapter.IPv4)
         {
-            if ($Adapter.IPv4.Address)
+            if (-not [String]::IsNullOrWhitespace($Adapter.IPv4.Address))
             {
 $DSCNetworkingConfig += @"
     xIPAddress IPv4_$AdapterCount {
@@ -981,7 +981,7 @@ $DSCNetworkingConfig += @"
     }
 
 "@
-                if ($Adapter.IPv4.DefaultGateway)
+                if (-not [String]::IsNullOrWhitespace($Adapter.IPv4.DefaultGateway))
                 {
 $DSCNetworkingConfig += @"
     xDefaultGatewayAddress IPv4G_$AdapterCount {
@@ -1015,7 +1015,7 @@ $DSCNetworkingConfig += @"
 "@
 
             } # If
-            if ($null -ne $Adapter.IPv4.DNSServer)
+            if (-not [String]::IsNullOrWhitespace($Adapter.IPv4.DNSServer))
             {
 $DSCNetworkingConfig += @"
     xDnsServerAddress IPv4D_$AdapterCount {
@@ -1029,7 +1029,7 @@ $DSCNetworkingConfig += @"
         } # If
         if ($Adapter.IPv6)
         {
-            if ($Adapter.IPv6.Address)
+            if (-not [String]::IsNullOrWhitespace($Adapter.IPv6.Address))
             {
 $DSCNetworkingConfig += @"
     xIPAddress IPv6_$AdapterCount {
@@ -1040,7 +1040,7 @@ $DSCNetworkingConfig += @"
     }
 
 "@
-                if ($Adapter.IPv6.DefaultGateway)
+                if (-not [String]::IsNullOrWhitespace($Adapter.IPv6.DefaultGateway))
                 {
 $DSCNetworkingConfig += @"
     xDefaultGatewayAddress IPv6G_$AdapterCount {
@@ -1074,7 +1074,7 @@ $DSCNetworkingConfig += @"
 "@
 
             } # If
-            if ($null -ne $Adapter.IPv6.DNSServer)
+            if (-not [String]::IsNullOrWhitespace($Adapter.IPv6.DNSServer))
             {
 $DSCNetworkingConfig += @"
     xDnsServerAddress IPv6D_$AdapterCount {

--- a/LabBuilder/lib/vhd.ps1
+++ b/LabBuilder/lib/vhd.ps1
@@ -403,7 +403,7 @@ function InitializeVhd
         Write-Verbose -Message ($LocalizedData.InitializeVHDInitializingMessage `
             -f $Path,$PartitionStyle)
 
-        Initialize-Disk `
+        $null = Initialize-Disk `
             -Number $DiskNumber `
             -PartitionStyle $PartitionStyle `
             -ErrorAction Stop
@@ -562,7 +562,7 @@ function InitializeVhd
                 }
 
                 # Add the Partition Access Path
-                Add-PartitionAccessPath `
+                $null = Add-PartitionAccessPath `
                     -DiskNumber $DiskNumber `
                     -PartitionNumber 1 `
                     -AccessPath $AccessPath `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 #      environment configuration  # 
 #---------------------------------# 
 os: WMF 5
-version: 0.7.0.{build}
+version: 0.7.1.{build}
 environment:
   PowerShellGalleryApiKey:
     secure: 3fXfDuds8yhTa7WTOLIEhytrpsej9kcP+4rPrgLaFVmIhimmc+FgUVxkR4u468LH
@@ -64,7 +64,7 @@ deploy_script:
 
       # Set version number
       $manifest = Join-Path -Path $VersionFolder -ChildPath "LabBuilder.psd1"
-      (Get-Content $manifest -Raw).Replace("0.7.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
+      (Get-Content $manifest -Raw).Replace("0.7.1.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
       
       # Create zip artifact
       $zipFilePath = Join-Path -Path $buildFolder -ChildPath "${env:APPVEYOR_PROJECT_NAME}_${env:APPVEYOR_BUILD_VERSION}.zip"


### PR DESCRIPTION
* GetDSCNetworkingConfig: Fix DSC error occuring when a blank DNS Server address or Default Gateway address is set on an Adapter.
* InitializeVhd: Prevent unnecessary results of disk partitioning and volume creation to console.

Also fixes #152 