### PR TITLE
Ensure all VMs are stopped in a Bootphase, even if timeout occurs - Fixes #162

### DIFF
--- a/LabBuilder/LabBuilder.psm1
+++ b/LabBuilder/LabBuilder.psm1
@@ -4780,7 +4780,7 @@ Function Start-Lab {
         } # if
     } # begin
 
-    process 
+    process
     {
         # Get the VMs
         $VMs = Get-LabVM `
@@ -4804,19 +4804,15 @@ Function Start-Lab {
                 Where-Object -FilterScript { ($_.BootOrder -eq $BootPhase) } )
 
             [DateTime] $StartPhase = Get-Date
-            [boolean] $PhaseComplete = $false
-            [boolean] $PhaseAllBooted = $true
+            [boolean] $PhaseComplete = $False
+            [boolean] $PhaseAllBooted = $True
             [int] $VMCount = $BootVMs.Count
             [int] $VMNumber = 0
-            [boolean] $FirstPassComplete = $false
-            
+
             # Loop through all the VMs in this "Bootphase" repeatedly
             # until timeout occurs or PhaseComplete is marked as complete
-            # Ensure that we also complete at least one full pass of all
-            # VMs in the "Bootphase"
             while (-not $PhaseComplete `
-                -and ((Get-Date) -lt $StartPhase.AddSeconds($StartupTimeout))`
-                -and -not $FirstPassComplete)
+                -and ((Get-Date) -lt $StartPhase.AddSeconds($StartupTimeout)))
             {
                 # Get the VM to boot/check
                 $VM = $BootVMs[$VMNumber]
@@ -4879,8 +4875,6 @@ Function Start-Lab {
                     } # if
                     # Reset the VM Loop
                     $VMNumber = 0
-                    # Flag that we have completed the first pass
-                    $FirstPassComplete = $True
                 } # if
             } # while
 
@@ -4896,7 +4890,7 @@ Function Start-Lab {
 
                 }
                 ThrowException @ExceptionParameters
-            }
+            } # if
         } # foreach
 
         Write-Verbose -Message $($LocalizedData.LabStartCompleteMessage `
@@ -5026,11 +5020,11 @@ Function Stop-Lab {
                 Where-Object -FilterScript { ($_.BootOrder -eq $BootPhase) } )
 
             [DateTime] $StartPhase = Get-Date
-            [boolean] $PhaseComplete = $false
-            [boolean] $PhaseAllStopped = $true
+            [boolean] $PhaseComplete = $False
+            [boolean] $PhaseAllStopped = $True
             [int] $VMCount = $BootVMs.Count
             [int] $VMNumber = 0
-            [boolean] $FirstPassComplete = $false
+            [boolean] $FirstPassComplete = $False
 
             # Loop through all the VMs in this "Bootphase" repeatedly
             # until timeout occurs or PhaseComplete is marked as complete
@@ -5115,7 +5109,7 @@ Function Stop-Lab {
 
                 }
                 ThrowException @ExceptionParameters
-            }
+            } # if
         } # foreach
 
         Write-Verbose -Message $($LocalizedData.LabStopCompleteMessage `

--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -4,7 +4,6 @@
 * docs\labbuilderconfig-schema.md: Converted to UTF-8 to eliminate issues with Git.
 * support\Convert-XSDToMD.ps1: Added code to convert transformed output to UTF-8.
 * Start-Lab: Improved readability if timeout detect code.
-             Ensure all VMs are started in a Bootphase, even if timeout occurs.
 * Stop-Lab: Improved readability if timeout detect code.
             Ensure all VMs are stopped in a Bootphase, even if timeout occurs.
 

--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -3,6 +3,10 @@
 * samples\Sample_WS2012R2_DomainClustering.xml: Added ServerName property to all Failover Cluster servers DSC properties.
 * docs\labbuilderconfig-schema.md: Converted to UTF-8 to eliminate issues with Git.
 * support\Convert-XSDToMD.ps1: Added code to convert transformed output to UTF-8.
+* Start-Lab: Improved readability if timeout detect code.
+             Ensure all VMs are started in a Bootphase, even if timeout occurs.
+* Stop-Lab: Improved readability if timeout detect code.
+            Ensure all VMs are stopped in a Bootphase, even if timeout occurs.
 
 ### 0.7.2.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Changed to install most File Server features on cluster nodes.


### PR DESCRIPTION
* Start-Lab: Improved readability if timeout detect code.
* Stop-Lab: Improved readability if timeout detect code.
            Ensure all VMs are stopped in a Bootphase, even if timeout occurs.