### PR TITLE
Added a WaitForDebugger parameter to StartDSCDebug - Fixes #163

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -6,6 +6,7 @@
 * Start-Lab: Improved readability if timeout detect code.
 * Stop-Lab: Improved readability if timeout detect code.
             Ensure all VMs are stopped in a Bootphase, even if timeout occurs.
+* StartDSCDebug.ps1: Added a WaitForDebugger parameter to StartDSCDebug.ps1 that will cause LCM to start with debugging mode enabled.
 
 ### 0.7.2.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Changed to install most File Server features on cluster nodes.

--- a/LabBuilder/lib/dsc.ps1
+++ b/LabBuilder/lib/dsc.ps1
@@ -639,13 +639,27 @@ Start-DSCConfiguration ``
         -Value $DSCStartPs -Force
 
     $DSCStartPsDebug = @"
+param (
+    [boolean] $WaitForDebugger
+)
 Set-DscLocalConfigurationManager ``
     -Path `"$($ENV:SystemRoot)\Setup\Scripts\`" ``
     -Verbose
+if ($WaitForDebugger)
+{
+    Enable-DscDebug ``
+        -BreakAll
+}
 Start-DSCConfiguration ``
     -Path `"$($ENV:SystemRoot)\Setup\Scripts\`" ``
-    -Force -Debug -Wait ``
+    -Force ``
+    -Debug ``
+    -Wait ``
     -Verbose
+if ($WaitForDebugger)
+{
+    Disable-DscDebug
+}
 "@
     $null = Set-Content `
         -Path (Join-Path -Path $VMLabBuilderFiles -ChildPath 'StartDSCDebug.ps1') `


### PR DESCRIPTION
* StartDSCDebug.ps1: Added a WaitForDebugger parameter to StartDSCDebug.ps1 that will cause LCM to start with debugging mode enabled.