### PR TITLE
Improve Handling of Convert-WindowsImage errors and support alternate DISM location - fixes #179

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -5,6 +5,10 @@
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_*.DSC.ps1: Added iSCSI Firewall Rules to allow iSNS registration.
 * DSCLibrary\MEMBER_ADFS.DSC.ps1: Added DSC Library configuration for ADRMS.
 * DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Added Incomplete DSC Library configuration for SQL Server 2014.
+* Support\Convert-WindowsImage.ps1: Updated to March 2016 version so that DISM path can be specified.
+* labbuilder-schema.xsd: Added Settings\DismPath attribute so that path to DISM can be specified.
+* Failure to validate Lab configuration XML will terminate any cmdlet immediately.
+* Any failure in Install-Lab will cause immediate build termination.
 
 ### 0.7.3.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.

--- a/LabBuilder/docs/labbuilderconfig-schema.md
+++ b/LabBuilder/docs/labbuilderconfig-schema.md
@@ -107,6 +107,18 @@ If this folder is not rooted, it will be assumed to be a subfolder of the 'labpa
                 
 ``` resourcepath="f:\SharedResources\" ```
 
+### 2.8a - DISMPATH Optional Attribute
+> dismpath="xs:string"
+
+
+This optional attribute contains the path to the copy of DISM.EXE that should be used to convert any Windows Install Media ISOs to VHD files.
+This is usually only required if the Lab Host is running Windows Server 2012 R2 or earlier or Windows 8.1 or earlier and the Windows Install Media ISO being converted is Windows Server 2016.
+The latest version of DISM can be found in the Windows ADK here https://msdn.microsoft.com/en-us/library/hh825494.aspx.
+Once the ADK is installed this setting can be configured to tell LabBuilder where to find the appropriate version (x86 or amd64) of DISM.
+You should not include the DISM.EXE application name in the path.
+                
+``` resourcepath="C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM\" ```
+
 ### 3.0e - RESOURCES Optional Element
 
 This optional element can contain one or more resources that will be required for this Lab to be installed.

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -90,6 +90,7 @@ ConvertFrom-StringData -StringData @'
     DSCConfiguartionMissingError=Start of Configuration could not be correctly identified in DSC Config.
     VolumeNotAvailableAfterMountError=The volume was not found after ISO File '{0}' was mounted.
     DriveLetterNotAssignedError=The volume was not found after ISO File '{0}' was mounted but a Drive Letter was not assigned.
+    ConvertWindowsImageError=An error occured converting {2} in '{1}' from ISO File '{0}' to a bootable {3}; {4}.
 
     ImportingLibFileMessage=Importing function library '{0}'.
     InstallingHyperVComponentsMesage=Installing {0} Hyper-V Components.

--- a/LabBuilder/lib/utils.ps1
+++ b/LabBuilder/lib/utils.ps1
@@ -440,11 +440,28 @@ function ValidateConfigurationXMLSchema {
         $Script:XMLErrorCount++
     });
     $reader = [System.Xml.XmlReader]::Create([string] $ConfigPath, $readerSettings)
-    while ($reader.Read())
+    try
     {
-    } # while
-    $null = $reader.Close()
-
+        while ($reader.Read())
+        {
+        } # while
+    } # try
+    catch
+    {
+        # XML is NOT valid
+        $ExceptionParameters = @{
+            errorId = 'ConfigurationXMLValidationError'
+            errorCategory = 'InvalidArgument'
+            errorMessage = $($LocalizedData.ConfigurationXMLValidationError `
+                -f $ConfigPath,$_.Exception.Message)
+        }
+        ThrowException @ExceptionParameters
+    } # catch
+    finally
+    {
+        $null = $reader.Close()
+    } # finally
+    
     # Verify the results of the XSD validation
     if($script:XMLErrorCount -gt 0)
     {

--- a/LabBuilder/schema/labbuilderconfig-schema.xsd
+++ b/LabBuilder/schema/labbuilderconfig-schema.xsd
@@ -92,6 +92,18 @@ If this folder is not rooted, it will be assumed to be a subfolder of the 'labpa
                 <xs:appinfo>resourcepath="f:\SharedResources\"</xs:appinfo>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="dismpath" type="xs:string" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+This optional attribute contains the path to the copy of DISM.EXE that should be used to convert any Windows Install Media ISOs to VHD files.
+This is usually only required if the Lab Host is running Windows Server 2012 R2 or earlier or Windows 8.1 or earlier and the Windows Install Media ISO being converted is Windows Server 2016.
+The latest version of DISM can be found in the Windows ADK here https://msdn.microsoft.com/en-us/library/hh825494.aspx.
+Once the ADK is installed this setting can be configured to tell LabBuilder where to find the appropriate version (x86 or amd64) of DISM.
+You should not include the DISM.EXE application name in the path.
+                </xs:documentation>
+                <xs:appinfo>resourcepath="C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM\"</xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
           </xs:complexType>
         </xs:element>
         <xs:element minOccurs="0" maxOccurs="1" name="resources">

--- a/LabBuilder/support/Convert-WindowsImage.ps1
+++ b/LabBuilder/support/Convert-WindowsImage.ps1
@@ -140,6 +140,13 @@ Convert-WindowsImage
             -nodhcp    - Prevents the use of DHCP to obtain the target IP address.
             -newkey    - Specifies that a new encryption key should be generated for the connection.
 
+    .PARAMETER DismPath
+        Full Path to an alternative version of the Dism.exe tool. The default is the current OS version.
+
+    .PARAMETER ApplyEA
+        Specifies that any EAs captured in the WIM should be applied to the VHD.
+        The default is False.
+
     .EXAMPLE
         .\Convert-WindowsImage.ps1 -SourcePath D:\foo\install.wim -Edition Professional -WorkingDirectory D:\foo
 
@@ -286,6 +293,16 @@ Convert-WindowsImage
         [Parameter(ParameterSetName="UI")]
         [switch]
         $Passthru,
+
+        [Parameter(ParameterSetName="SRC")]
+        [string]
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript({ Test-Path $(Resolve-Path $_) })]
+        $DismPath,
+
+        [Parameter(ParameterSetName="SRC")]
+        [switch]
+        $ApplyEA = $false,
 
         [Parameter(ParameterSetName="UI")]
         [switch]
@@ -570,18 +587,18 @@ Convert-WindowsImage
         $PARTITION_STYLE_GPT    = 0x00000001                                   # Just in case...
 
         # Version information that can be populated by timebuild.
-        $ScriptVersion = DATA 
+        $ScriptVersion = DATA
         {
-            ConvertFrom-StringData -StringData @"
-Major     = 10
-Minor     = 0
-Build     = 10586
-Qfe       = 0
-Branch    = th2_release
-Timestamp = 151029-1700
-Flavor    = amd64fre
+    ConvertFrom-StringData -StringData @"
+        Major     = 10
+        Minor     = 0
+        Build     = 14278
+        Qfe       = 1000
+        Branch    = rs1_es_media
+        Timestamp = 160201-1707
+        Flavor    = amd64fre
 "@
-        }
+}
 
         $myVersion              = "$($ScriptVersion.Major).$($ScriptVersion.Minor).$($ScriptVersion.Build).$($ScriptVersion.QFE).$($ScriptVersion.Flavor).$($ScriptVersion.Branch).$($ScriptVersion.Timestamp)"
         $scriptName             = "Convert-WindowsImage"                       # Name of the script, obviously.
@@ -787,7 +804,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                 [ValidateNotNullOrEmpty()]
                 $text
             )
-            Write-Host "ERROR  : $($text)"
+            Write-Host "ERROR  : $($text)" -ForegroundColor (Get-Host).PrivateData.ErrorForegroundColor
         }
 
         ##########################################################################################
@@ -2003,15 +2020,30 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
             ####################################################################################################
 
             Write-W2VInfo "Applying image to $VHDFormat. This could take a while..."
-            if (Get-Command Expand-WindowsImage -ErrorAction SilentlyContinue)
+            if ((Get-Command Expand-WindowsImage -ErrorAction SilentlyContinue) -and ((-not $ApplyEA) -and ([string]::IsNullOrEmpty($DismPath))))
             {
                 Expand-WindowsImage -ApplyPath $windowsDrive -ImagePath $SourcePath -Index $ImageIndex -LogPath "$($logFolder)\DismLogs.log" | Out-Null
             }
             else
             {
-                $dismArgs = @("/Apply-Image /ImageFile:`"$SourcePath`" /Index:$ImageIndex /ApplyDir:$windowsDrive /LogPath:`"$($logFolder)\DismLogs.log`"")
-                Write-W2VInfo "Applying image: $Dism $dismArgs"
-                $process  = Start-Process -Passthru -Wait -NoNewWindow -FilePath $(Join-Path $env:WinDir "system32\dism.exe") `
+                if (![string]::IsNullOrEmpty($DismPath))
+                {
+                    $dismPath = $DismPath
+                }
+                else
+                {
+                    $dismPath = $(Join-Path (get-item env:\windir).value "system32\dism.exe")
+                }
+
+                $applyImage = "/Apply-Image"
+                if ($ApplyEA)
+                {
+                    $applyImage = $applyImage + " /EA"
+                }
+
+                $dismArgs = @("$applyImage /ImageFile:`"$SourcePath`" /Index:$ImageIndex /ApplyDir:$windowsDrive /LogPath:`"$($logFolder)\DismLogs.log`"")
+                Write-W2VInfo "Applying image: $dismPath $dismArgs"
+                $process  = Start-Process -Passthru -Wait -NoNewWindow -FilePath $dismPath `
                             -ArgumentList $dismArgs `
 
                 if ($process.ExitCode -ne 0)
@@ -4023,4 +4055,3 @@ VirtualHardDisk
 
     Add-Type -TypeDefinition $code -ReferencedAssemblies "System.Xml","System.Linq","System.Xml.Linq" -ErrorAction SilentlyContinue
 }
-

--- a/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
@@ -10,8 +10,9 @@
             email="tester@pester.local"
             labpath="C:\Pester Lab"
             vhdparentpath="C:\Pester Lab\Virtual Hard Disk Templates"
-            dsclibrarypath="DSCLibrary" 
-            resourcepath="Resource" />
+            dsclibrarypath="DSCLibrary"
+            resourcepath="Resource"
+            dismpath="C:\dism" />
 
   <resources>
     <module name="xNetworking" url="https://github.com/PlagueHO/xNetworking/archive/dev.zip" folder="xNetworking-dev" />

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -762,10 +762,38 @@ InModuleScope LabBuilder {
         {
             . "$Global:ModuleRoot\support\Convert-WindowsImage.ps1"
         }
-        Mock Convert-WindowsImage 
+        Mock Convert-WindowsImage
         Mock Resolve-Path -MockWith { 'X:\Sources\Install.WIM' }
-        Mock Test-Path -MockWith { $True } -ParameterFilter { $Path -eq 'X:\Sources\Install.WIM' }
-                
+        Mock Test-Path -ParameterFilter { $Path -eq 'X:\Sources\Install.WIM' } -MockWith { $True }
+        Mock Test-Path -ParameterFilter { $Path -eq '
+            C:\dism\dism.exe' } -MockWith { $False }
+
+        Context 'Configuration passed but alternate DISM not found' {
+            It 'Throws a FileNotFoundError exception' {
+                $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
+                $VMTemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab
+                $ExceptionParameters = @{
+                    errorId = 'FileNotFoundError'
+                    errorCategory = 'InvalidArgument'
+                    errorMessage = $($LocalizedData.FileNotFoundError `
+                        -f 'alternate DISM.EXE','C:\dism\dism.exe')
+                }
+                { Initialize-LabVMTemplateVHD -Lab $Lab -VMTemplateVHDs $VMTemplateVHDs } | Should Throw $Exception
+            }
+            It 'Calls expected mocks commands' {
+                Assert-MockCalled Mount-DiskImage -Exactly 0
+                Assert-MockCalled Get-Diskimage -Exactly 0
+                Assert-MockCalled Get-Volume -Exactly 0
+                Assert-MockCalled Dismount-DiskImage -Exactly 0
+                Assert-MockCalled Get-WindowsImage -Exactly 0
+                Assert-MockCalled Copy-Item -Exactly 0
+                Assert-MockCalled Rename-Item -Exactly 0
+                Assert-MockCalled Convert-WindowsImage -Exactly 0
+            }
+        }
+
+        Mock Test-Path -ParameterFilter { $Path -eq 'C:\dism\dism.exe' } -MockWith { $True }
+
         Context 'Configuration passed with no VMtemplateVHDs' {
             It 'Does not throw an Exception' {
                 $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
@@ -781,7 +809,7 @@ InModuleScope LabBuilder {
                 Assert-MockCalled Copy-Item -Exactly 0
                 Assert-MockCalled Rename-Item -Exactly 0
                 Assert-MockCalled Convert-WindowsImage -Exactly 0
-            }            
+            }
         }
         Context 'Configuration passed where the template ISO can not be found' {
             It 'Throws an VMTemplateVHDISOPathNotFoundError Exception' {
@@ -902,13 +930,38 @@ InModuleScope LabBuilder {
                 Assert-MockCalled Convert-WindowsImage -Exactly 0
             }
         }
+        Context 'Valid configuration passed but Convert-WindowsImage throws' {
+            Mock Convert-WindowsImage -MockWith { Throw 'Convert-WindowsImage Exception' }
+            Mock Test-Path -ParameterFilter { $Path -eq $ResourceMSUFile } -MockWith { $True }
+            It 'Does not throw an Exception' {
+                $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
+                $VMTemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab
+                $ExceptionParameters = @{
+                    errorId = 'ConvertWindowsImageError'
+                    errorCategory = 'InvalidArgument'
+                    errorMessage = $($LocalizedData.ConvertWindowsImageError `
+                        -f $VMTemplateVHDs[0].ISOPath,'X:\Sources\Install.WIM',$VMTemplateVHDs[0].Edition,$VMTemplateVHDs[0].VHDFormat,'Convert-WindowsImage Exception')
+                }
+                { Initialize-LabVMTemplateVHD -Lab $Lab -VMTemplateVHDs $VMTemplateVHDs } | Should Throw $Exception
+            }
+            It 'Calls expected mocks commands' {
+                Assert-MockCalled Mount-DiskImage -Exactly 1
+                Assert-MockCalled Get-Diskimage -Exactly 1
+                Assert-MockCalled Get-Volume -Exactly 1
+                Assert-MockCalled Dismount-DiskImage -Exactly 1
+                Assert-MockCalled Get-WindowsImage -Exactly 0
+                Assert-MockCalled Copy-Item -Exactly 0
+                Assert-MockCalled Rename-Item -Exactly 0
+                Assert-MockCalled Convert-WindowsImage -Exactly 1
+            }
+        }
     }
 
 
     Describe 'Remove-LabVMTemplateVHD' {
         $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
         $VMTemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab
-        Mock Remove-Item                        
+        Mock Remove-Item
         Mock Test-Path -MockWith { $False }
         Context 'Configuration passed with VMtemplateVHDs but VHD not found' {
             It 'Does not throw an Exception' {

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Some common ISO download locations:
  - Windows 10 Enterprise: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise
  - Windows Server 2016 TP4: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-technical-preview
 
+**Important**: If you are converting Windows Server 2016 ISO files or adding packages to VHDs please see the [Windows Server 2016](#Windows Server 2016) section.
+
 Multiple VHD templates may use the same ISO file in a Lab.
 For example, if multiple editions of an Operating system are used in the same lab.
 
@@ -170,6 +172,29 @@ In that case, you can set the _vhdpath_ attribute of the _<templatevhds>_ node i
 The conversion process for a single ISO to VHD can take 10-20 minutes depending on your machine.
 For this reason multiple Labs can be configured to use the same path to store these VHDs by changing the _vhdpath_ attribute of the _<templatevhds>_ node in the configuration. 
 
+Windows Server 2016
+===================
+
+If you are converting a Windows Server 2016 image and your Lab Host is running either:
+ - Windows Server 2012 R2 or older
+ - Windows 8.1 or older
+
+You will need to install an updated version of the DISM before you will be able to add any packages to a Windows Server 2016 ISO.
+This includes building Nano Server Images.
+
+You can get the latest version of the DISM by downloading and installing the [Windows ADK](http://go.microsoft.com/fwlink/?LinkId=293394).
+After installing the Windows ADK, you can force LabBuilder to use this version by configuring the "dismpath" attribute in the "settings" element of your LabBuilder configuration file:
+```xml
+<labbuilderconfig xmlns="labbuilderconfig"
+                  name="PesterTestConfig"
+                  version="1.0">
+  <description>My Lab</description>
+
+  <settings labid="TestLab"
+            domainname="CONTOSO.COM"
+            labpath="C:\Lab"
+            dismpath="C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM" />
+```
 
 Lab Installation Process in Detail
 ==================================


### PR DESCRIPTION
This PR contains the following fixes/changes:

* Support\Convert-WindowsImage.ps1: Updated to March 2016 version so that DISM path can be specified.
* labbuilder-schema.xsd: Added Settings\DismPath attribute so that path to DISM can be specified.
* Failure to validate Lab configuration XML will terminate any cmdlet immediately.
* Any failure in Install-Lab will cause immediate build termination.

- Fixes #179 

@m0rgenthau:
What I've done is added a new **dismpath** attribute to the <Settings> in the config that allows you to specify an alternate path to the location where DISM is (in your case C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM).

If set, this dismpath will be passed to Convert-WindowsImage (they added a new option to all the path to DISM.EXE to be specified in the March 2016 version). This won't completely do away with the problem but it will make it easier to manage.

I also added a section in the Readme.md covering this.

I've also improved the handling of errors when building labs to ensure that an error will cause the build to terminate. At some point I may improve this to optionally clean up the failed lab.

Again, good catch!