### PR TITLE
Fixed incorrect error reported when invalid Edition is specified - Fixes #178

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -9,6 +9,7 @@
 * labbuilder-schema.xsd: Added Settings\DismPath attribute so that path to DISM can be specified.
 * Failure to validate Lab configuration XML will terminate any cmdlet immediately.
 * Any failure in Install-Lab will cause immediate build termination.
+* Support\Convert-WindowsImage.ps1: Fixed incorrect error reported when invalid Edition is specified.
 
 ### 0.7.3.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.

--- a/LabBuilder/support/Convert-WindowsImage.ps1
+++ b/LabBuilder/support/Convert-WindowsImage.ps1
@@ -1818,21 +1818,17 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $WindowsImage = Get-WindowsImage -ImagePath $SourcePath | Where-Object {$_.ImageName -ilike "*$($Edition)"}
                 }
 
-                if (-not $WindowsImage -or ($WindowsImage -is [System.Array]))
+                if (-not $WindowsImage)
+                {
+                    throw "Requested windows Image was not found on the WIM file!"
+                }
+                if ($WindowsImage -is [System.Array])
                 {
                     Write-W2VInfo "WIM file has the following $($WindowsImage.Count) images that match filter *$($Edition)"
                     Get-WindowsImage -ImagePath $SourcePath
 
-                    if (-not $WindowsImage)
-                    {
-                        throw "Requested windows Image was not found on the WIM file!!"
-                    }
-                    else
-                    {
-                        Write-W2VError "You must specify an Edition or SKU index, since the WIM has more than one image."
-
-                        throw "There are more than one images that match ImageName filter *$($Edition)"
-                    }
+                    Write-W2VError "You must specify an Edition or SKU index, since the WIM has more than one image."
+                    throw "There are more than one images that match ImageName filter *$($Edition)"
                 }
             }
 


### PR DESCRIPTION
- Fixes #178 

@m0rgenthau: I've made a fix to the LabBuilder copy of Convert-WindowsImage.ps1 to correctly report the error that occurs when the edition specified can't be found in the WIM.

I've also submitted a PR with the same change to Microsoft so that hopefully they'll incorporate the fix too: https://github.com/Microsoft/Virtualization-Documentation/pull/186

Thanks again!
