### PR TITLE
Generalized Nano Server package support - Fixes #177

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -15,6 +15,8 @@
 * DSCLibrary\MEMBER_NANO.DSC.ps1: Added DSC Library configuration for joining a Nano server to n AD Domain.
 * labbuilder-schema.xsd: Fixed VM attribute descriptions.
 * Added CertificateSource attribute to VM to support controlling where any Lab Certificates should be generated from when initializing a Lab VM.
+* Generalized Nano Server package support.
+* Both ResourceMSU and Nano Server packages can now be installed on Template VHDs and Virtual Machines.
 
 ### 0.7.3.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.

--- a/LabBuilder/docs/labbuilderconfig-schema.md
+++ b/LabBuilder/docs/labbuilderconfig-schema.md
@@ -521,13 +521,20 @@ Valid Values: PowerShell numeric values (e.g. 2GB, 1TB, 300MB, 160000000).
 > packages="xs:string"
 
 
-This optional attribute can contain a comma delimited list of packages that should be installed into this Virtual Machine Template VHD. 
+This optional attribute can contain a comma delimited list of packages that should be installed into this Virtual Machine Template VHD.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Template VHD is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
-Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
+If the Template VHD is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
                       
-``` packages="Storage,Guest" ```
+``` packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu" ```
 
 ### 6.0e - TEMPLATES Optional Element
 
@@ -697,13 +704,20 @@ Currently this is only supported on Windows 10 built 10586 or above and Windows 
 > packages="xs:string"
 
 
-This optional attribute can contain a comma delimited list of packages that should be installed onto any Virtual Machines using this Template. 
+This optional attribute can contain a comma delimited list of packages that should be installed onto any Virtual Machines using this Template.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Template is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
- - Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
-                      
-``` packages="Storage,Guest" ```
+If the Template is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
+                       
+``` packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu" ```
 
 ### 7.0e - VMS Optional Element
 
@@ -874,11 +888,18 @@ If this attribute is not defined, but it is defined in the Template then the tem
 This optional attribute can contain a comma delimited list of packages that should be installed onto this Virtual Machine.
 If this attribute is not defined, but it is defined in the Template then the template value will be used, otherwise the default value will be used.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Virtual Machine is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
- - Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
+If the Virtual Machine is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
                       
-``` packages="Storage,Guest" ```
+``` packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu" ```
 
 ### 7.1.15a - BOOTORDER Optional Attribute
 > bootorder="xs:unsignedByte"

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -83,6 +83,7 @@ ConvertFrom-StringData -StringData @'
     VMDVDDriveISOResourceNotFOundError=The ISO Resource '{1}' to be mounted into a Virtual DVD Drive specified in VM '{0}' does not exist.
     NanoServerPackagesFolderMissingError=The NanoServerPackages folder '{0}' does not exist.
     VMDoesNotExistError=The VM '{0}' does not exist.
+    NanoPackageNotFoundError=The Nano Server Package '{0}' could not be found.
     PackageNotFoundError=The Package MSU '{0}' is not listed in the Lab Resource MSU list.
     PackageMSUNotFoundError=The file '{1}' for Package MSU '{0}' does not exist.
     BootPhaseStartVMsTimeoutError=One or more Virtual Machines with Bootorder '{0}' failed to start completely in the required time.

--- a/LabBuilder/schema/labbuilderconfig-schema.xsd
+++ b/LabBuilder/schema/labbuilderconfig-schema.xsd
@@ -522,13 +522,20 @@ Valid Values: PowerShell numeric values (e.g. 2GB, 1TB, 300MB, 160000000).
                   <xs:attribute name="packages" type="xs:string" use="optional">
                     <xs:annotation>
                       <xs:documentation>
-This optional attribute can contain a comma delimited list of packages that should be installed into this Virtual Machine Template VHD. 
+This optional attribute can contain a comma delimited list of packages that should be installed into this Virtual Machine Template VHD.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Template VHD is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
-Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
+If the Template VHD is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
                       </xs:documentation>
-                      <xs:appinfo>packages="Storage,Guest"</xs:appinfo>
+                      <xs:appinfo>packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu"</xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
                 </xs:complexType>
@@ -727,19 +734,26 @@ Currently this is only supported on Windows 10 built 10586 or above and Windows 
                   <xs:attribute name="packages" type="xs:string" use="optional">
                     <xs:annotation>
                       <xs:documentation>
-This optional attribute can contain a comma delimited list of packages that should be installed onto any Virtual Machines using this Template. 
+This optional attribute can contain a comma delimited list of packages that should be installed onto any Virtual Machines using this Template.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Template is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
- - Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
-                      </xs:documentation>
-                      <xs:appinfo>packages="Storage,Guest"</xs:appinfo>
+If the Template is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
+                       </xs:documentation>
+                      <xs:appinfo>packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu"</xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
-            <xs:attribute name="fromvm" type="xs:string" use="optional">            
+            <xs:attribute name="fromvm" type="xs:string" use="optional">
               <xs:annotation>
                 <xs:documentation>
 This optional attribute enables the list of Template Virtual Machines to be pulled from the Virtual Machines defined in Hyper-V.
@@ -1350,11 +1364,18 @@ If this attribute is not defined, but it is defined in the Template then the tem
 This optional attribute can contain a comma delimited list of packages that should be installed onto this Virtual Machine.
 If this attribute is not defined, but it is defined in the Template then the template value will be used, otherwise the default value will be used.
 
-Note: Currently, this is only used to install packages on Nano Server Virtual Machines, but may be extended to install MSU packages.
+If the Virtual Machine is a Nano Server then the packages can be .cab files, which will install the Nano Server package from the ISO or a Resource MSU file.
 
- - Valid Values (for Nano Server): Compute | OEM-Drivers | Storage | FailoverCluster | ReverseForwarders | Guest | Containers | Defender | DCB | DNS | DSC | IIS | NPDS | SCVMM | SCVMM-Compute
+If the Virtual Machine is not a Nano Server then the packages must be Resource MSU files.
+
+Valid Values:
+ - Resource MSU names that are can be found in the ResourceMSU list.
+
+Valid Values for Nano Server:
+ - Filename including the .cab extension of a valid Nano Server package found on the Windows Install Media ISO.
+ - Resource MSU names that are can be found in the ResourceMSU list.
                       </xs:documentation>
-                      <xs:appinfo>packages="Storage,Guest"</xs:appinfo>
+                      <xs:appinfo>packages="Microsoft-NanoServer-DNS-Package.cab,SomePackage.msu"</xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
                   <xs:attribute name="bootorder" type="xs:unsignedByte" use="optional">

--- a/LabBuilder/tests/pestertestconfig/vhdfiles/Windows Server 2016 TP4 Datacenter Core.vhdx
+++ b/LabBuilder/tests/pestertestconfig/vhdfiles/Windows Server 2016 TP4 Datacenter Core.vhdx
@@ -1,0 +1,1 @@
+This is a dummy VHDx

--- a/LabBuilder/tests/pestertestconfig/vhdfiles/Windows Server 2016 TP4 Datacenter Full.vhdx
+++ b/LabBuilder/tests/pestertestconfig/vhdfiles/Windows Server 2016 TP4 Datacenter Full.vhdx
@@ -1,0 +1,1 @@
+This is a dummy VHDx

--- a/LabBuilder/tests/unit/lib/vhd.tests.ps1
+++ b/LabBuilder/tests/unit/lib/vhd.tests.ps1
@@ -125,6 +125,7 @@ InModuleScope LabBuilder {
             Mock Test-Path -ParameterFilter { $Path -eq $NanoServerPackagesFolder } -MockWith { $True }
             It 'Does Not Throw Exception' {
                 $VM = $VMs[0].Clone()
+                $VM.Packages = ''
                 $VM.OSType = [LabOStype]::Nano
                 { InitializeBootVHD -Lab $Lab -VM $VM -VMBootDiskPath 'c:\Dummy\' } | Should Not Throw
             }
@@ -140,10 +141,11 @@ InModuleScope LabBuilder {
         }
         Context 'Valid Configuration Passed with Nano Server VM and two packages' {
             Mock Test-Path -ParameterFilter { $Path -eq $NanoServerPackagesFolder } -MockWith { $True }
+            Mock Test-Path -ParameterFilter { $Path -like "$NanoServerPackagesFolder\*.cab" } -MockWith { $True }
             It 'Does Not Throw Exception' {
                 $VM = $VMs[0].Clone()
                 $VM.OSType = [LabOStype]::Nano
-                $VM.Packages = 'Containers,Guest'
+                $VM.Packages = 'Microsoft-NanoServer-Containers-Package.cab,Microsoft-NanoServer-Guest-Package.cab'
                 { InitializeBootVHD -Lab $Lab -VM $VM -VMBootDiskPath 'c:\Dummy\' } | Should Not Throw
             }
             It 'Calls Mocked commands' {
@@ -153,7 +155,28 @@ InModuleScope LabBuilder {
                 Assert-MockCalled Add-WindowsPackage -Exactly 4
                 Assert-MockCalled Copy-Item -Exactly 3
                 Assert-MockCalled Remove-Item -Exactly 1
-                Assert-MockCalled Test-Path -Exactly 1
+                Assert-MockCalled Test-Path -Exactly 5
+            }
+        }
+        Context 'Valid Configuration Passed with Nano Server VM and two packages and an MSU' {
+            Mock Test-Path -ParameterFilter { $Path -eq $NanoServerPackagesFolder } -MockWith { $True }
+            Mock Test-Path -ParameterFilter { $Path -like "$NanoServerPackagesFolder\*.cab" } -MockWith { $True }
+            Mock Test-Path -ParameterFilter { $Path -eq $ResourceMSUFile } -MockWith { $True }
+
+            It 'Does Not Throw Exception' {
+                $VM = $VMs[0].Clone()
+                $VM.OSType = [LabOStype]::Nano
+                $VM.Packages = 'Microsoft-NanoServer-Containers-Package.cab,Microsoft-NanoServer-Guest-Package.cab,WMF5.0-WS2012R2-W81'
+                { InitializeBootVHD -Lab $Lab -VM $VM -VMBootDiskPath 'c:\Dummy\' } | Should Not Throw
+            }
+            It 'Calls Mocked commands' {
+                Assert-MockCalled New-Item -Exactly 3
+                Assert-MockCalled Mount-WindowsImage -Exactly 1
+                Assert-MockCalled Dismount-WindowsImage -Exactly 1
+                Assert-MockCalled Add-WindowsPackage -Exactly 5
+                Assert-MockCalled Copy-Item -Exactly 3
+                Assert-MockCalled Remove-Item -Exactly 1
+                Assert-MockCalled Test-Path -Exactly 6
             }
         }
         Context 'Valid Configuration Passed with Nano Server VM and two packages but NanoServerPackages folder missing' {
@@ -161,7 +184,7 @@ InModuleScope LabBuilder {
             It 'Throws a NanoServerPackagesFolderMissingError exception' {
                 $VM = $VMs[0].Clone()
                 $VM.OSType = [LabOStype]::Nano
-                $VM.Packages = 'Containers,Guest'
+                $VM.Packages = 'Microsoft-NanoServer-Containers-Package.cab,Microsoft-NanoServer-Guest-Package.cab'
                 $ExceptionParameters = @{
                     errorId = 'NanoServerPackagesFolderMissingError'
                     errorCategory = 'InvalidArgument'


### PR DESCRIPTION
* Generalized Nano Server package support.
* Both ResourceMSU and Nano Server packages can now be installed on Template VHDs and Virtual Machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/186)
<!-- Reviewable:end -->
