### PR TITLE
Automatically add Microsoft-NanoServer-DSC-Package.cab to new Nano Server VMs - Fixes #187

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -17,6 +17,7 @@
 * Added CertificateSource attribute to VM to support controlling where any Lab Certificates should be generated from when initializing a Lab VM.
 * Generalized Nano Server package support.
 * Both ResourceMSU and Nano Server packages can now be installed on Template VHDs and Virtual Machines.
+* Automatically add Microsoft-NanoServer-DSC-Package.cab to new Nano Server VMs.
 
 ### 0.7.3.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.

--- a/LabBuilder/lib/vhd.ps1
+++ b/LabBuilder/lib/vhd.ps1
@@ -70,6 +70,7 @@ function InitializeBootVHD {
 
     try
     {
+        $Packages = $VM.Packages
         if ($VM.OSType -eq [LabOSType]::Nano)
         {
             # Now specify the Nano Server packages to add.
@@ -86,16 +87,28 @@ function InitializeBootVHD {
                 }
                 ThrowException @ExceptionParameters
             }
-        }
-
+            # Add DSC Package to packages list if missing
+            if ([String]::IsNullOrWhitespace($Packages))
+            {
+                $Packages = 'Microsoft-NanoServer-DSC-Package.cab'
+            }
+            else
+            {
+                if (@($Packages -split ',') -notcontains 'Microsoft-NanoServer-DSC-Package.cab')
+                {
+                    $Pacakges = "$Packages,Microsoft-NanoServer-DSC-Package.cab"
+                } # if
+            } # if
+        } # if
+        
         # Apply any listed packages to the Image
-        if (-not [String]::IsNullOrWhitespace($VM.Packages))
+        if (-not [String]::IsNullOrWhitespace($Packages))
         {
             # Get the list of Lab Resource MSUs
             $ResourceMSUs = Get-LabResourceMSU `
                 -Lab $Lab
 
-            foreach ($Package in @($VM.Packages -split ','))
+            foreach ($Package in @($Packages -split ','))
             {
                 if (([System.IO.Path]::GetExtension($Package) -eq '.cab') `
                     -and ($VM.OSType -eq [LabOSType]::Nano))

--- a/LabBuilder/tests/unit/lib/vhd.tests.ps1
+++ b/LabBuilder/tests/unit/lib/vhd.tests.ps1
@@ -123,6 +123,7 @@ InModuleScope LabBuilder {
         }
         Context 'Valid Configuration Passed with Nano Server VM and no packages' {
             Mock Test-Path -ParameterFilter { $Path -eq $NanoServerPackagesFolder } -MockWith { $True }
+            Mock Test-Path -ParameterFilter { $Path -like "$NanoServerPackagesFolder\*.cab" } -MockWith { $True }
             It 'Does Not Throw Exception' {
                 $VM = $VMs[0].Clone()
                 $VM.Packages = ''
@@ -133,10 +134,10 @@ InModuleScope LabBuilder {
                 Assert-MockCalled New-Item -Exactly 3
                 Assert-MockCalled Mount-WindowsImage -Exactly 1
                 Assert-MockCalled Dismount-WindowsImage -Exactly 1
-                Assert-MockCalled Add-WindowsPackage -Exactly 0
+                Assert-MockCalled Add-WindowsPackage -Exactly 2
                 Assert-MockCalled Copy-Item -Exactly 3
                 Assert-MockCalled Remove-Item -Exactly 1
-                Assert-MockCalled Test-Path -Exactly 1
+                Assert-MockCalled Test-Path -Exactly 3
             }
         }
         Context 'Valid Configuration Passed with Nano Server VM and two packages' {


### PR DESCRIPTION
* Automatically add Microsoft-NanoServer-DSC-Package.cab to new Nano Server VMs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/188)
<!-- Reviewable:end -->
