### PR TITLE
Improve handling of External Virtual Switch adapter binding - Fixes #189

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -18,6 +18,7 @@
 * Generalized Nano Server package support.
 * Both ResourceMSU and Nano Server packages can now be installed on Template VHDs and Virtual Machines.
 * Automatically add Microsoft-NanoServer-DSC-Package.cab to new Nano Server VMs.
+* Added BindingAdapterName and BindingAdapterMac attribute to swtich element to allow control over bound adapter.
 
 ### 0.7.3.0
 * DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.

--- a/LabBuilder/docs/labbuilderconfig-schema.md
+++ b/LabBuilder/docs/labbuilderconfig-schema.md
@@ -307,7 +307,7 @@ It can be set to:
  - Internal
  - Private
  - External
- - NAT  
+ - NAT (only available on some Windows 10 versions and Windows Server 2016)
                       
 ``` type="Internal" ```
 
@@ -315,9 +315,29 @@ It can be set to:
 > vlan="xs:unsignedByte"
 
 
-This optional attribute is used to configure the VLAN ID of all Virtual Network Adapters that will connect to this Virtual Switch. 
+This optional attribute is used to configure the VLAN ID of all Virtual Network Adapters that will connect to this Virtual Switch.
                       
 ``` vlan="43" ```
+
+### 4.1.4a - BINDINGADAPTERNAME Optional Attribute
+> bindingadaptername="xs:string"
+
+
+This optional attribute is used to configure which physical network adapter an External switch will be bound to.
+This attribute should only be set if the switch type is External.
+If the bindingadaptermac attribute is set then this attribute should not be set.
+                      
+``` bindingadaptername="Ethernet 1" ```
+
+### 4.1.5a - BINDINGADAPTERMAC Optional Attribute
+> bindingadaptermac="xs:string"
+
+
+This optional attribute is used to configure which physical network adapter an External switch will be bound to.
+This attribute should only be set if the switch type is External.
+If the bindingadaptername attribute is set then this attribute should not be set.
+                      
+``` bindingadaptermac="C86000A1A895" ```
 
 ### 4.1.1e - ADAPTERS Optional Element
 

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -92,6 +92,8 @@ ConvertFrom-StringData -StringData @'
     VolumeNotAvailableAfterMountError=The volume was not found after ISO File '{0}' was mounted.
     DriveLetterNotAssignedError=The volume was not found after ISO File '{0}' was mounted but a Drive Letter was not assigned.
     ConvertWindowsImageError=An error occured converting {2} in '{1}' from ISO File '{0}' to a bootable {3}; {4}.
+    BindingAdapterNotFoundError=A physical network adapter {1}was not found to bind to the External Switch {0}.
+    BindingAdapterUsedError=Error binding physical network adapter '{1}' to External Swtich '{0}' because it is already bound to another External Switch.
 
     ImportingLibFileMessage=Importing function library '{0}'.
     InstallingHyperVComponentsMesage=Installing {0} Hyper-V Components.

--- a/LabBuilder/schema/labbuilderconfig-schema.xsd
+++ b/LabBuilder/schema/labbuilderconfig-schema.xsd
@@ -358,7 +358,7 @@ It can be set to:
  - Internal
  - Private
  - External
- - NAT  
+ - NAT (only available on some Windows 10 versions and Windows Server 2016)
                       </xs:documentation>
                       <xs:appinfo>type="Internal"</xs:appinfo>
                     </xs:annotation>
@@ -366,9 +366,29 @@ It can be set to:
                   <xs:attribute name="vlan" type="xs:unsignedByte" use="optional">
                     <xs:annotation>
                       <xs:documentation>
-This optional attribute is used to configure the VLAN ID of all Virtual Network Adapters that will connect to this Virtual Switch. 
+This optional attribute is used to configure the VLAN ID of all Virtual Network Adapters that will connect to this Virtual Switch.
                       </xs:documentation>
                       <xs:appinfo>vlan="43"</xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="bindingadaptername" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+This optional attribute is used to configure which physical network adapter an External switch will be bound to.
+This attribute should only be set if the switch type is External.
+If the bindingadaptermac attribute is set then this attribute should not be set.
+                      </xs:documentation>
+                      <xs:appinfo>bindingadaptername="Ethernet 1"</xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="bindingadaptermac" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+This optional attribute is used to configure which physical network adapter an External switch will be bound to.
+This attribute should only be set if the switch type is External.
+If the bindingadaptername attribute is set then this attribute should not be set.
+                      </xs:documentation>
+                      <xs:appinfo>bindingadaptermac="C86000A1A895"</xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
                 </xs:complexType>

--- a/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
@@ -28,7 +28,7 @@
   </resources>
 
   <switches>
-    <switch name="External" type="External" >
+    <switch name="External" type="External" bindingadaptername="Ethernet">
       <adapters>
         <adapter name="Cluster" macaddress="00155D010701" vlan="5"/>
         <adapter name="Management" macaddress="00155D010702" vlan="6"/>

--- a/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
+++ b/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
@@ -4,7 +4,7 @@
         "Type":  3,
         "VLAN":  0,
         "NATSubnetAddress":  "",
-        "BindingAdapterName":  "",
+        "BindingAdapterName":  "Ethernet",
         "BindingAdapterMac":  "",
         "Adapters":  [
                          {

--- a/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
+++ b/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
@@ -4,6 +4,8 @@
         "Type":  3,
         "VLAN":  0,
         "NATSubnetAddress":  "",
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
         "Adapters":  [
                          {
                              "Name":  "Cluster",
@@ -32,6 +34,8 @@
         "Type":  1,
         "VLAN":  2,
         "NATSubnetAddress":  "",
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
         "Adapters":  null
     },
     {
@@ -39,6 +43,8 @@
         "Type":  1,
         "VLAN":  0,
         "NATSubnetAddress":  "",
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
         "Adapters":  null
     },
     {
@@ -46,6 +52,8 @@
         "Type":  2,
         "VLAN":  3,
         "NATSubnetAddress":  "",
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
         "Adapters":  null
     },
     {
@@ -53,6 +61,8 @@
         "Type":  2,
         "VLAN":  0,
         "NATSubnetAddress":  "",
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
         "Adapters":  null
     }
 ]

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -372,36 +372,50 @@ InModuleScope LabBuilder {
         $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
         [LabSwitch[]] $Switches = Get-LabSwitch -Lab $Lab
 
-        Mock Get-VMSwitch
+        Mock Get-VMSwitch -MockWith {
+            @{
+                Name = 'Dummy Switch'
+            }
+        }
         Mock New-VMSwitch
         Mock Add-VMNetworkAdapter
         Mock Set-VMNetworkAdapterVlan
+        Mock Get-NetAdapter -MockWith {
+            @{
+                Name       = 'Ethernet'
+                MACAddress = '0012345679A0'
+                Status     = 'Up'
+                Virtual    = $False
+            }
+        }
 
-        Context 'Valid configuration is passed' {	
+        Context 'Valid configuration is passed' {
             It 'Does not throw an Exception' {
                 { Initialize-LabSwitch -Lab $Lab -Switches $Switches } | Should Not Throw
             }
             It 'Calls Mocked commands' {
-                Assert-MockCalled Get-VMSwitch -Exactly 5
+                Assert-MockCalled Get-VMSwitch -Exactly 6
                 Assert-MockCalled New-VMSwitch -Exactly 5
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 4
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 2
             }
         }
 
-        Context 'Valid configuration without switches is passed' {	
+        Context 'Valid configuration without switches is passed' {
             It 'Does not throw an Exception' {
                 { Initialize-LabSwitch -Lab $Lab } | Should Not Throw
             }
             It 'Calls Mocked commands' {
-                Assert-MockCalled Get-VMSwitch -Exactly 5
+                Assert-MockCalled Get-VMSwitch -Exactly 6
                 Assert-MockCalled New-VMSwitch -Exactly 5
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 4
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 2
             }
         }
 
-        Context 'Valid configuration NAT with blank NAT Subnet Address' {	
+        Context 'Valid configuration NAT with blank NAT Subnet Address' {
             $Switches[0].Type = [LabSwitchType]::NAT
             It 'Throws a NatSubnetAddressEmptyError Exception' {
                 $ExceptionParameters = @{
@@ -419,10 +433,11 @@ InModuleScope LabBuilder {
                 Assert-MockCalled New-VMSwitch -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 0
             }
         }
 
-        Context 'Valid configuration with blank switch name passed' {	
+        Context 'Valid configuration with blank switch name passed' {
             $Switches[0].Type = [LabSwitchType]::External
             $Switches[0].Name = ''
             It 'Throws a SwitchNameIsEmptyError Exception' {
@@ -440,6 +455,55 @@ InModuleScope LabBuilder {
                 Assert-MockCalled New-VMSwitch -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 0
+            }
+        }
+
+        [LabSwitch[]] $Switches = Get-LabSwitch -Lab $Lab
+
+        Context 'Valid configuration with External switch with binding Adapter name bad' {
+            Mock Get-NetAdapter
+            It 'Throws a BindingAdapterNotFoundError Exception' {
+                $ExceptionParameters = @{
+                    errorId = 'BindingAdapterNotFoundError'
+                    errorCategory = 'InvalidArgument'
+                    errorMessage = $($LocalizedData.BindingAdapterNotFoundError `
+                        -f $Switches[0].Name,"with a name '$($Switches[0].BindingAdapterName)' ")
+                }
+                $Exception = GetException @ExceptionParameters
+
+                { Initialize-LabSwitch -Lab $Lab -Switches $Switches } | Should Throw $Exception
+            }
+            It 'Calls Mocked commands' {
+                Assert-MockCalled Get-VMSwitch -Exactly 1
+                Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
+                Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 1
+            }
+        }
+
+        Context 'Valid configuration with External switch with binding Adapter MAC bad' {
+            Mock Get-NetAdapter
+            $Switches[0].BindingAdapterName = ''
+            $Switches[0].BindingAdapterMac = '1111111111'
+            It 'Throws a BindingAdapterNotFoundError Exception' {
+                $ExceptionParameters = @{
+                    errorId = 'BindingAdapterNotFoundError'
+                    errorCategory = 'InvalidArgument'
+                    errorMessage = $($LocalizedData.BindingAdapterNotFoundError `
+                        -f $Switches[0].Name,"with a MAC address '$($Switches[0].BindingAdapterMac)' ")
+                }
+                $Exception = GetException @ExceptionParameters
+
+                { Initialize-LabSwitch -Lab $Lab -Switches $Switches } | Should Throw $Exception
+            }
+            It 'Calls Mocked commands' {
+                Assert-MockCalled Get-VMSwitch -Exactly 1
+                Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
+                Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
+                Assert-MockCalled Get-NetAdapter -Exactly 1
             }
         }
     }

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -378,6 +378,7 @@ InModuleScope LabBuilder {
             }
         }
         Mock New-VMSwitch
+        Mock Get-VMNetworkAdapter
         Mock Add-VMNetworkAdapter
         Mock Set-VMNetworkAdapterVlan
         Mock Get-NetAdapter -MockWith {
@@ -396,6 +397,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 6
                 Assert-MockCalled New-VMSwitch -Exactly 5
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 4
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 2
@@ -409,6 +411,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 6
                 Assert-MockCalled New-VMSwitch -Exactly 5
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 4
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 2
@@ -431,6 +434,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 1
                 Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 0
@@ -453,6 +457,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 1
                 Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 0
@@ -477,6 +482,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 1
                 Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 1
@@ -501,6 +507,7 @@ InModuleScope LabBuilder {
             It 'Calls Mocked commands' {
                 Assert-MockCalled Get-VMSwitch -Exactly 1
                 Assert-MockCalled New-VMSwitch -Exactly 0
+                Assert-MockCalled Get-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Add-VMNetworkAdapter -Exactly 0
                 Assert-MockCalled Set-VMNetworkAdapterVlan -Exactly 0
                 Assert-MockCalled Get-NetAdapter -Exactly 1


### PR DESCRIPTION
* Added BindingAdapterName and BindingAdapterMac attribute to switch element to allow control over bound adapter.

The BindingAdapterName and BindingAdapterMac attributes should not be used on the same switch - either specify the name of the adapter or the MAC address. If both are specified only the MAC address is used.

If the Binding Adapter is found but is used by another external switch then an exception is thrown reporting this.

If no Binding Adapter attributes are specified then the first Physical adapter with an 'Up' status will be used. If it is already used the an exception will be thrown reporting this.

@m0rgenthau - if you get a chance, could you see if this change solves things for you? I've updated the Schema documentation with details of the new Attributes:
BindingAdapterName
BindingAdapterMac

Thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/190)
<!-- Reviewable:end -->
