### PR TITLE
Fix to Prevent ExposeVirtualizationExtensions from being used prior to Host 10585 - Fixes #199

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -1,5 +1,7 @@
 ### Unreleased
 * Added VM InstanceCount attribute for creating multiple copies a VM in a Lab.
+* Added $Script:CurrentBuild variable to allow easier access to OS build version.
+* Fix to prevent ExposeVirtualizationExtensions from being applied on Lab Hosts that don't support it.
 
 ### 0.7.4.0
 * lib\vm.ps1: WaitWMStarted - name of integrationservice "heartbeat" detected by id to be culture neutral

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -83,6 +83,7 @@ ConvertFrom-StringData -StringData @'
     VMDVDDriveISOResourceNotFOundError=The ISO Resource '{1}' to be mounted into a Virtual DVD Drive specified in VM '{0}' does not exist.
     NanoServerPackagesFolderMissingError=The NanoServerPackages folder '{0}' does not exist.
     VMDoesNotExistError=The VM '{0}' does not exist.
+    VMVirtualizationExtError=The VM '{0}' requires Virtualization Extensions to be exposed, but this is not supported by your version of Windows. Either set the ExposeVirtualizationExtensions attribute to 'N' for the VM or update to a Windows Build 10565 or above.
     NanoPackageNotFoundError=The Nano Server Package '{0}' could not be found.
     PackageNotFoundError=The Package MSU '{0}' is not listed in the Lab Resource MSU list.
     PackageMSUNotFoundError=The file '{1}' for Package MSU '{0}' does not exist.

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -85,6 +85,8 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
 
 
     # Perform Configuration XML Schema validation
@@ -2049,8 +2051,6 @@ InModuleScope LabBuilder {
         Mock Initialize-LabVMDSC
         Mock Install-LabVMDSC
         #endregion
-        # Run tests assuming Build 10586 is installed
-        $Script:CurrentBuild = 10586
 
         Context 'Valid configuration is passed' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -1413,6 +1413,9 @@ InModuleScope LabBuilder {
         Mock Get-VM
         #endregion
 
+        # Run tests assuming Build 10586 is installed
+        $Script:CurrentBuild = 10586
+
         # Figure out the TestVMName (saves typing later on)
         $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
         $TestVMName = "$($Lab.labbuilderconfig.settings.labid) $($Lab.labbuilderconfig.vms.vm.name)"
@@ -1961,6 +1964,23 @@ InModuleScope LabBuilder {
                 $VMs.Count | Should Be 0
             }
         }
+        $Script:CurrentBuild = 10560
+        Context 'Configuration passed with ExposeVirtualizationExtensions required but Build is 10560.' {
+            It 'Throw DSCConfigNameIsEmptyError Exception' {
+                $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
+                [Array]$Switches = Get-LabSwitch -Lab $Lab
+                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $ExceptionParameters = @{
+                    errorId = 'VMVirtualizationExtError'
+                    errorCategory = 'InvalidArgument'
+                    errorMessage = $($LocalizedData.VMVirtualizationExtError `
+                        -f $TestVMName)
+                }
+                $Exception = GetException @ExceptionParameters
+                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should Throw $Exception
+            }
+        }
+        $Script:CurrentBuild = 10586
         Context 'Valid configuration is passed but switches and VMTemplates not passed' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             # Set the Instance Count to 2 to check
@@ -2029,8 +2049,10 @@ InModuleScope LabBuilder {
         Mock Initialize-LabVMDSC
         Mock Install-LabVMDSC
         #endregion
+        # Run tests assuming Build 10586 is installed
+        $Script:CurrentBuild = 10586
 
-        Context 'Valid configuration is passed' {	
+        Context 'Valid configuration is passed' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             New-Item -Path $Lab.labbuilderconfig.settings.labpath -ItemType Directory -Force -ErrorAction SilentlyContinue
             New-Item -Path $Lab.labbuilderconfig.settings.vhdparentpath -ItemType Directory -Force -ErrorAction SilentlyContinue

--- a/LabBuilder/tests/unit/lib/dsc.tests.ps1
+++ b/LabBuilder/tests/unit/lib/dsc.tests.ps1
@@ -43,9 +43,10 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
 
 
-    
     Describe 'GetModulesInDSCConfig' {
         Context 'Called with Test DSC Resource File' {
             It 'Returns DSCModules Object that matches Expected Object' {

--- a/LabBuilder/tests/unit/lib/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/switch.tests.ps1
@@ -43,9 +43,11 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
-    
-    
-    
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
+
+
+
     Describe 'IsAdmin' -Tag 'Incomplete' {
     }
 }

--- a/LabBuilder/tests/unit/lib/utils.tests.ps1
+++ b/LabBuilder/tests/unit/lib/utils.tests.ps1
@@ -43,6 +43,8 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
 
 
 

--- a/LabBuilder/tests/unit/lib/vhd.tests.ps1
+++ b/LabBuilder/tests/unit/lib/vhd.tests.ps1
@@ -43,7 +43,9 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
-    
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
+
 
 
     Describe 'InitializeBootVHD' {

--- a/LabBuilder/tests/unit/lib/vm.tests.ps1
+++ b/LabBuilder/tests/unit/lib/vm.tests.ps1
@@ -43,7 +43,10 @@ InModuleScope LabBuilder {
             -ArgumentList $exception, $errorId, $errorCategory, $null
         return $errorRecord
     }
-    
+    # Run tests assuming Build 10586 is installed
+    $Script:CurrentBuild = 10586
+
+
     Describe 'CreateVMInitializationFiles' -Tags 'Incomplete' {
     }
 


### PR DESCRIPTION
* Added $Script:CurrentBuild variable to allow easier access to OS build version.
* Fix to prevent ExposeVirtualizationExtensions from being applied on Lab Hosts that don't support it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/200)
<!-- Reviewable:end -->
