### PR TITLE
Fix to correct Nano Server language package filename

### DIFF
--- a/LabBuilder/LabBuilder.psm1
+++ b/LabBuilder/LabBuilder.psm1
@@ -537,3 +537,6 @@ class LabDSCModule:System.ICloneable {
 [String] $Script:ConfigurationXMLTemplate = Join-Path `
     -Path $PSScriptRoot `
     -ChildPath 'template\labbuilderconfig-template.xml'
+
+# Nano Stuff
+[String] $Script:NanoPackageCulture = 'en-us'

--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -3,6 +3,7 @@
 * Moved existing Libs into Libs\Private folder.
 * Updated samples and tests to support Windows Server 2016 TP5.
 * Updated Visual Studio Project and Soltion files.
+* Fix Nano Server localization package filename support for TP5.
 
 ### 0.7.5.0
 * Added VM InstanceCount attribute for creating multiple copies a VM in a Lab.

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -33,9 +33,9 @@ ConvertFrom-StringData -StringData @'
     EmptyTemplateNameError=Template Name is missing or empty.
     TemplateSourceVHDAndTemplateVHDConflictError=Both the Template SourceVHD and TemplateVHD parameters are set for Template '{0}'. Only one of these may be set for each Template.
     TemplateSourceVHDandTemplateVHDMissingError=Either the Template SourceVHD or TemplateVHD parameter must be set in Template '{0}'.
-    TemplateTemplateVHDNotFoundError=The Template Template VHD '{1}' in Template '{0}' could not be found.
+    TemplateTemplateVHDNotFoundError=The Template VHD '{1}' in Template '{0}' could not be found.
     TemplateSourceVHDNotFoundError=The Template Source VHD '{1}' in Template '{0}' could not be found.
-    DSCModuleDownloadError=Module '{2}' required by DSC Config File '{0}' in VM '{1}' could not be found or downloaded.					
+    DSCModuleDownloadError=Module '{2}' required by DSC Config File '{0}' in VM '{1}' could not be found or downloaded.
     DSCModuleNotFoundError=Module '{2}' required by DSC Config File '{0}' in VM '{1}' could not be found in the module path.
     CertificateCreateError=The self-signed certificate for VM '{0}' could not be created and downloaded.
     CertificateDownloadError=The self-signed certificate for VM '{0}' could not be downloaded.

--- a/LabBuilder/lib/private/vhd.ps1
+++ b/LabBuilder/lib/private/vhd.ps1
@@ -140,9 +140,10 @@ function InitializeBootVHD {
                         -Path $MountPoint
 
                     # Generate the path to the Nano Language Package
+                    $PackageLangFile = $Package -replace '.cab',"_$($Script:NanoPackageCulture).cab"
                     $PackageLangFile = Join-Path `
                         -Path $NanoPackagesFolder `
-                        -ChildPath "en-us\$Package"
+                        -ChildPath "$($Script:NanoPackageCulture)\$PackageLangFile"
 
                     # Does it exist?
                     if (-not (Test-Path -Path $PackageLangFile))

--- a/LabBuilder/lib/public/templatevhd.ps1
+++ b/LabBuilder/lib/public/templatevhd.ps1
@@ -600,9 +600,10 @@ function Initialize-LabVMTemplateVHD
                         $Packages += @( $PackagePath )
 
                         # Generate the path to the Nano Language Package
+                        $PackageLangFile = $Package -replace '.cab',"_$($Script:NanoPackageCulture).cab"
                         $PackageLangPath = Join-Path `
                             -Path $NanoPackagesFolder `
-                            -ChildPath "en-us\$Package"
+                            -ChildPath "$($Script:NanoPackageCulture)\$PackageLangFile"
                         # Does it exist?
                         if (-not (Test-Path -Path $PackageLangPath))
                         {

--- a/LabBuilder/template/labbuilderconfig-template.xml
+++ b/LabBuilder/template/labbuilderconfig-template.xml
@@ -87,7 +87,7 @@
                  url="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-technical-preview"
                  vhd="Nano Server 2016 TP5 Basic.vhdx"
                  ostype="Nano"
-                 packages="Guest"
+                 packages="Microsoft-NanoServer-Guest-Package.cab"
                  vhdformat="vhdx" 
                  vhdtype="dynamic" 
                  generation="2"

--- a/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
@@ -103,7 +103,7 @@
                  url="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-technical-preview"
                  vhd="Nano Server 2016 TP5 Basic.vhdx"
                  ostype="Nano"
-                 packages="Guest"
+                 packages="Microsoft-NanoServer-Guest-Package.cab"
                  vhdformat="vhdx" 
                  vhdtype="dynamic" 
                  generation="2"

--- a/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedTemplateVHDs.json
+++ b/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedTemplateVHDs.json
@@ -85,7 +85,7 @@
         "VHDPath":  "Intentionally Removed",
         "Edition":  "",
         "Packages":  [
-                         "Guest"
+                         "Microsoft-NanoServer-Guest-Package.cab"
                      ],
         "Features":  null
     }

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ By default LabBuilder will look in the **isofiles** subfolder of your Lab folder
 You can change the folder that a Lab looks in for the ISO files by changing/setting the _isopath_ attribute of the _<templatevhds>_ node in the configuration
 If it can't find an ISO file it needs, you will be notified of an official download location for trial or preview editions of the ISO files (as long as the LabBuilder configuration you're using contains the download URLs).
 
-Some common ISO download locations:  
+Some common ISO download locations:
  - Windows Server 2012 R2: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2
  - Windows 10 Enterprise: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-10-enterprise
  - Windows Server 2016 TP5: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-technical-preview
@@ -179,6 +179,8 @@ If you are converting a Windows Server 2016 image and your Lab Host is running e
  - Windows Server 2012 R2 or older
  - Windows 8.1 or older
 
+**Important:** Only Windows Server 2016 Technical Preview 5 and above are supported with LabBilder.
+ 
 You will need to install an updated version of the DISM before you will be able to add any packages to a Windows Server 2016 ISO.
 This includes building Nano Server Images.
 


### PR DESCRIPTION
Nano Server package filename format for the language files changed in TP5. This is a breaking change and will cause Nano Server in TP4 to no longer be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/213)
<!-- Reviewable:end -->
