### PR TITLE
Fix Support for NAT Switches in Windows build 14295 and above - Fixes #228

### DIFF
--- a/LabBuilder/LabBuilder.psm1
+++ b/LabBuilder/LabBuilder.psm1
@@ -365,9 +365,10 @@ class LabSwitch:System.ICloneable {
     [String] $Name
     [LabSwitchType] $Type
     [Byte] $VLAN
-    [String] $NATSubnetAddress
     [String] $BindingAdapterName
     [String] $BindingAdapterMac
+    [String] $NatSubnet
+    [String] $NatGatewayAddress
     [LabSwitchAdapter[]] $Adapters
 
     LabSwitch() {}

--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -1,6 +1,8 @@
-###Unreleased
-*Fixed failure when creating self-signed certificate on localized systems, by replacing EKU Names with IDs
-
+# Unreleased
+* Fixed failure when creating self-signed certificate on localized systems, by replacing EKU Names with IDs.
+* Fixed support for NAT switches and added Switch attributes NatSubnet and NatGatewayAddress.
+* Private function UpdateSwitchManagementAdapter added.
+* Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Added sample for testing NAT based Lab switches.
 
 # 0.7.8.0
 * Install-Lab: Force flag added to suppress confirmation messages.

--- a/LabBuilder/docs/labbuilderconfig-schema.md
+++ b/LabBuilder/docs/labbuilderconfig-schema.md
@@ -307,7 +307,7 @@ It can be set to:
  - Internal
  - Private
  - External
- - NAT (only available on some Windows 10 versions and Windows Server 2016)
+ - NAT (only available on Windows 10 and Windows Server 2016 build 14295 and above)
                       
 ``` type="Internal" ```
 
@@ -338,6 +338,28 @@ This attribute should only be set if the switch type is External.
 If the bindingadaptername attribute is set then this attribute should not be set.
                       
 ``` bindingadaptermac="C86000A1A895" ```
+
+### 4.1.6a - NATSUBNET Optional Attribute
+> natsubnet="xs:string"
+
+
+This optional attribute is used to configure the subnet that will be assigned to this NAT switch.
+It must contain an IP address (192.168.10.0) followed by a slash (/) then the subnet prefix length (e.g. 24).
+This attribute should only be set if the switch type is NAT.
+If this attribute is set the natgatewayaddress attribute must also be set.
+                      
+``` natsubnet="192.168.10.0/24" ```
+
+### 4.1.7a - NATGATEWAYADDRESS Optional Attribute
+> natgatewayaddress="xs:string"
+
+
+This optional attribute is used to configure the IP address that will be used as a gateway address on this NAT switch.
+This IP Address must be within the defined NAT subnet set in the natsubnet attribute.
+This attribute should only be set if the switch type is NAT.
+If this attribute is set the natsubnet attribute must also be set.
+                      
+``` natgatewayaddress="192.168.10.1" ```
 
 ### 4.1.1e - ADAPTERS Optional Element
 

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -18,8 +18,13 @@ ConvertFrom-StringData -StringData @'
     ModuleNotAvailableError=Error installing Module '{0}' ({1}); {2}.
     SwitchNameIsEmptyError=Switch name is missing or empty.
     UnknownSwitchTypeError=Unknown switch type '{0}' specified for switch '{1}'.
-    AdapterSpecifiedError=Adapter specified on '{0}' switch '{1}'.
-    NatSubnetAddressEmptyError=Switch NAT Subnet Address is empty '{0}'.
+    AdapterSpecifiedError=Adater specified on '{0}' switch '{1}'.
+    NatSwitchNotSupportedError=NAT Switch '{0}' is not supported. NAT Switches are only supported on build Windows 10 or Windows Server 2016 build 14295 and above.
+    NatSubnetEmptyError=NAT Switch '{0}' subnet is empty.
+    NatSubnetInvalidError=NAT Switch '{0}' subnet format '{1}' is invalid. It must contain IP address and prefix length. E.g '192.168.1.1/24'.
+    NatSubnetAddressInvalidError=NAT Switch '{0}' subnet address '{1}' is invalid.
+    NatSubnetPrefixLengthInvalidError=NAT Switch '{0}' subnet prefix length '{1}' is invalid.
+    NatSwitchDefaultAdapterMacEmptyError=NAT Switch '{0}' default virtual network adapter MAC address is empty.
     EmptyVMTemplateVHDNameError=Template VHD name is missing or empty.
     EmptyVMTemplateVHDISOPathError=The ISO Path in VM Template VHD '{0}' is empty.
     EmptyVMTemplateVHDPathError=The VHD Path in VM Template VHD '{0}' is empty.

--- a/LabBuilder/lib/private/switch.ps1
+++ b/LabBuilder/lib/private/switch.ps1
@@ -32,3 +32,81 @@ function GetManagementSwitchName {
 
     return $ManagementSwitchName
 } # GetManagementSwitchName
+
+<#
+.SYNOPSIS
+    Ensures that the Management OS virtual adapter is attached to a Virtual Switch.
+.DESCRIPTION
+    This function is used to add or update the specified virtual network adapter
+    that is used by the Management OS to connect to the specifed virtual switch.
+.PARAMETER Name
+    Contains the name of the virtual network adapter to add.
+.PARAMETER SwitchName
+    Contains the name of the virtual switch to connect this adapter to.
+.PARAMETER StaticMacAddress
+    This optional parameter contains the static MAC address to assign to the virtual
+    network adapter.
+.PARAMETER VlanId
+    This optional parameter contains the VLan Id to assign to this network adapter.
+.EXAMPLE
+    UpdateSwitchManagementAdapter -Name 'Domain Nat SMB' -SwitchName 'Domain Nat' -VlanId 25 
+.OUTPUTS
+    None.
+#>
+function UpdateSwitchManagementAdapter {
+    [CmdLetBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [String] $Name,
+
+        [Parameter(Mandatory)]
+        [String] $SwitchName,
+
+        [String] $StaticMacAddress,
+
+        [Byte] $VLanId
+    )
+    # Remove VLanId Parameter so this can be splatted
+    $PSBoundParameters.Remove('VLanId')
+    $PSBoundParameters.Remove('StaticMacAddress')
+
+    $Adapter = Get-VMNetworkAdapter `
+        -ManagementOS `
+        @PSBoundParameters `
+        -ErrorAction Stop
+    if (-not $Adapter)
+    {
+        # Adapter does not exist so add it
+        $Adapter = Add-VMNetworkAdapter `
+            -ManagementOS `
+            @PSBoundParameters `
+            -Passthru
+    } # if
+
+    # Set or clear the static mac address
+    if ([String]::IsNullOrEmpty($StaticMacAddress))
+    {
+        $MacSplat = @{ DynamicMacAddress = $true }
+    }
+    else
+    { 
+        $MacSplat = @{ StaticMacAddress = $StaticMacAddress }
+    } # if
+    $Adapter | Set-VMNetworkAdapter `
+        @MacSplat `
+        -ErrorAction Stop
+
+    # Set or clear the VLanId
+    if ($VLanId)
+    {
+        $VlanSplat = @{ VlanId = $VlanId }
+    }
+    else
+    { 
+        $VlanSplat = @{ Untagged = $True }
+    } # if
+    $Adapter | Set-VMNetworkAdapterVlan `
+        -Access `
+        @VlanSplat `
+        -ErrorAction Stop
+} # UpdateSwitchManagementAdapter

--- a/LabBuilder/lib/public/switch.ps1
+++ b/LabBuilder/lib/public/switch.ps1
@@ -406,7 +406,7 @@ function Initialize-LabSwitch {
                     if ($NetNat)
                     {
                         # If the NAT already exists, remove it so it can be recreated
-                        $null = $NetNat | Remove-NetNat
+                        $null = $NetNat | Remove-NetNat -Confirm:$False
                     }
                     # Create the new NAT
                     $null = New-NetNat `

--- a/LabBuilder/lib/public/switch.ps1
+++ b/LabBuilder/lib/public/switch.ps1
@@ -122,9 +122,11 @@ function Get-LabSwitch {
         # Create the new Switch object
         [LabSwitch] $NewSwitch = [LabSwitch]::New($SwitchName,$SwitchType)
         $NewSwitch.VLAN = $ConfigSwitch.VLan
-        $NewSwitch.NATSubnetAddress = $ConfigSwitch.NatSubnetAddress
         $NewSwitch.BindingAdapterName = $ConfigSwitch.BindingAdapterName
         $NewSwitch.BindingAdapterMac = $ConfigSwitch.BindingAdapterMac
+        $NewSwitch.BindingAdapterMac = $ConfigSwitch.BindingAdapterMac
+        $NewSwitch.NatSubnet = $ConfigSwitch.NatSubnet
+        $NewSwitch.NatGatewayAddress = $ConfigSwitch.NatGatewayAddress
         $NewSwitch.Adapters = $ConfigAdapters
         $Switches += @( $NewSwitch )
     } # foreach
@@ -260,10 +262,11 @@ function Initialize-LabSwitch {
                     $MacAddress = @()
                     ForEach ($VmSwitchName in $VmSwitchNames)
                     {
-                        $MacAddress += `
-                            (Get-VMNetworkAdapter `
+                        $MacAddress += (Get-VMNetworkAdapter `
                             -ManagementOS `
-                            -Name $VmSwitchName -ErrorAction SilentlyContinue).MacAddress
+                            -SwitchName $VmSwitchName `
+                            -Name $VmSwitchName `
+                            -ErrorAction SilentlyContinue).MacAddress
                     } # foreach
 
                     $UsedAdapters = @((Get-NetAdapter -Physical | ? {
@@ -282,36 +285,7 @@ function Initialize-LabSwitch {
                     # Create the swtich
                     $null = New-VMSwitch `
                         -Name $SwitchName `
-                        -NetAdapterName ($BindingAdapter.Name)
-                    if ($VMSwitch.Adapters)
-                    {
-                        foreach ($Adapter in $VMSwitch.Adapters)
-                        {
-                            if ($VMSwitch.VLan)
-                            {
-                                # A default VLAN is assigned to this Switch so assign it to the
-                                # management adapters
-                                $null = Add-VMNetworkAdapter `
-                                    -ManagementOS `
-                                    -SwitchName $SwitchName `
-                                    -Name $Adapter.Name `
-                                    -StaticMacAddress $Adapter.MacAddress `
-                                    
-                                    -Passthru | `
-                                    Set-VMNetworkAdapterVlan `
-                                        -Access `
-                                        -VlanId $($VMSwitch.Vlan)
-                            }
-                            else
-                            { 
-                                $null = Add-VMNetworkAdapter `
-                                    -ManagementOS `
-                                    -SwitchName $SwitchName `
-                                    -Name $Adapter.Name `
-                                    -StaticMacAddress $Adapter.MacAddress
-                            } # if
-                        } # foreach
-                    } # if
+                        -NetAdapterName $BindingAdapter.Name
                     break
                 } # 'External'
                 'Private'
@@ -326,55 +300,120 @@ function Initialize-LabSwitch {
                     $null = New-VMSwitch `
                         -Name $SwitchName `
                         -SwitchType Internal
-                    if ($VMSwitch.Adapters)
-                    {
-                        foreach ($Adapter in $VMSwitch.Adapters)
-                        {
-                            if ($VMSwitch.VLan)
-                            {
-                                # A default VLAN is assigned to this Switch so assign it to the
-                                # management adapters
-                                $null = Add-VMNetworkAdapter `
-                                    -ManagementOS `
-                                    -SwitchName $SwitchName `
-                                    -Name $($Adapter.Name) `
-                                    -StaticMacAddress $($Adapter.MacAddress) `
-                                    -Passthru | `
-                                    Set-VMNetworkAdapterVlan `
-                                        -Access `
-                                        -VlanId $($VMSwitch.Vlan)
-                            }
-                            Else
-                            { 
-                                $null = Add-VMNetworkAdapter `
-                                    -ManagementOS `
-                                    -SwitchName $SwitchName `
-                                    -Name $($Adapter.Name) `
-                                    -StaticMacAddress $($Adapter.MacAddress)
-                            } # if
-                        } # foreach
-                    } # if
                     Break
                 } # 'Internal'
                 'NAT'
                 {
-                    $NatSubnetAddress = $VMSwitch.NatSubnetAddress
-                    if (-not $NatSubnetAddress) {
+                    if ($Script:CurrentBuild -lt 14295)
+                    {
                         $ExceptionParameters = @{
-                            errorId = 'NatSubnetAddressEmptyError'
+                            errorId = 'NatSwitchNotSupportedError'
                             errorCategory = 'InvalidArgument'
-                            errorMessage = $($LocalizedData.NatSubnetAddressEmptyError `
+                            errorMessage = $($LocalizedData.NatSwitchNotSupportedError `
                                 -f $SwitchName)
                         }
                         ThrowException @ExceptionParameters
                     }
+                    $NatSubnet = $VMSwitch.NatSubnet
+                    # Check Nat Subnet is set
+                    if (-not $NatSubnet) {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSubnetEmptyError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSubnetEmptyError `
+                                -f $SwitchName)
+                        }
+                        ThrowException @ExceptionParameters
+                    } # if
+                    # Ensure Nat Subnet looks valid
+                    if ($NatSubnet -notmatch '[0-9]+.[0-9]+.[0-9]+.[0-9]+/[0-9]+') {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSubnetInvalidError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSubnetInvalidError `
+                                -f $SwitchName,$NatSubnet)
+                        }
+                        ThrowException @ExceptionParameters
+                    } # if
+                    $NatSubnetComponents = ($NatSubnet -split '/')
+                    $NatSubnetAddress = $NatSubnetComponents[0]
+                    # Validate the Nat Subnet Address
+                    if (-not ([System.Net.Ipaddress]::TryParse($NatSubnetAddress, [ref]0)))
+                    {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSubnetAddressInvalidError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSubnetAddressInvalidError `
+                                -f $SwitchName,$NatSubnetAddress)
+                        }
+                        ThrowException @ExceptionParameters
+                    } # if
+                    # Validate the Nat Subnet Prefix Length
+                    [int] $NatSubnetPrefixLength = $NatSubnetComponents[1]
+                    if (($NatSubnetPrefixLength -lt 1) -or ($NatSubnetPrefixLength -gt 31))
+                    {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSubnetPrefixLengthInvalidError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSubnetPrefixLengthInvalidError `
+                                -f $SwitchName,$NatSubnetPrefixLength)
+                        }
+                        ThrowException @ExceptionParameters
+                    } # if
+                    $NatGatewayAddress = $VMSwitch.NatGatewayAddress
+
+                    # Create the Internal Switch
                     $null = New-VMSwitch `
                         -Name $SwitchName `
-                        -SwitchType NAT `
-                        -NATSubnetAddress $NatSubnetAddress
+                        -SwitchType Internal `
+                        -ErrorAction Stop
+                    # Set the IP Address on the default adapter connected to the NAT switch
+                    $MacAddress = (Get-VMNetworkAdapter `
+                        -ManagementOS `
+                        -SwitchName $SwitchName `
+                        -Name $SwitchName `
+                        -ErrorAction Stop).MacAddress
+                    if ([String]::IsNullOrEmpty($MacAddress))
+                    {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSwitchDefaultAdapterMacEmptyError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSwitchDefaultAdapterMacEmptyError `
+                                -f $SwitchName)
+                        }
+                        ThrowException @ExceptionParameters
+                    } # if
+                    $Adapter = Get-NetAdapter |
+                        Where-Object { ($_.MacAddress -replace '-','') -eq $MacAddress }
+                    if (-not $Adapter)
+                    {
+                        $ExceptionParameters = @{
+                            errorId = 'NatSwitchDefaultAdapterNotFoundError'
+                            errorCategory = 'InvalidArgument'
+                            errorMessage = $($LocalizedData.NatSwitchDefaultAdapterNotFoundError `
+                                -f $SwitchName)
+                        }
+                        ThrowException @ExceptionParameters
+                    }
+                    elseif ($Adapter | Get-NetIPAddress)
+                    {
+                        $Adapter | Set-NetIPAddress `
+                                -IPAddress $NatGatewayAddress `
+                                -PrefixLength $NatSubnetPrefixLength `
+                                -ErrorAction Stop
+                    }
+                    else
+                    {
+                        $Adapter | New-NetIPAddress `
+                                -IPAddress $NatGatewayAddress `
+                                -PrefixLength $NatSubnetPrefixLength `
+                                -ErrorAction Stop
+                    } # if
+                    # Convert the Internal switch to a NAT switch
                     $null = New-NetNat `
                         -Name $SwitchName `
-                        -InternalIPInterfaceAddressPrefix $NatSubnetAddress
+                        -InternalIPInterfaceAddressPrefix $NatSubnet `
+                        -ErrorAction Stop
                     Break
                 } # 'NAT'
                 Default
@@ -387,7 +426,42 @@ function Initialize-LabSwitch {
                     }
                     ThrowException @ExceptionParameters
                 }
-            } # Switch
+            } # switch
+
+            if ($SwitchType -ne 'Private')
+            {
+                # Configure the VLan on the default Management Adapter
+                $Splat = @{
+                    Name = $SwitchName
+                    SwitchName = $SwitchName
+                }
+                if ($VMSwitch.VLan)
+                {
+                    $Splat += @{ VlanId = $VMSwitch.Vlan }
+                } # if
+                UpdateSwitchManagementAdapter @Splat
+            
+                # Add any management OS adapters to the switch
+                if ($VMSwitch.Adapters)
+                {
+                    foreach ($Adapter in $VMSwitch.Adapters)
+                    {
+                        $Splat = @{
+                            Name = $Adapter.Name
+                            SwitchName = $SwitchName
+                        }
+                        if ($Adapter.MacAddress)
+                        {
+                            $Splat += @{ StaticMacAddress = $Adapter.MacAddress }
+                        } # if
+                        if ($VMSwitch.VLan)
+                        {
+                            $Splat += @{ VlanId = $VMSwitch.Vlan }
+                        } # if
+                        UpdateSwitchManagementAdapter @Splat
+                    } # foreach
+                } # if
+            } # if
         } # if
     } # foreach
 } # Initialize-LabSwitch
@@ -510,7 +584,7 @@ function Remove-LabSwitch {
                 } # 'Internal'
                 'NAT'
                 {
-                    Remove-NetNAT `
+                    Remove-NetNat `
                         -Name $SwitchName
                     Remove-VMSwitch `
                         -Name $SwitchName

--- a/LabBuilder/lib/public/switch.ps1
+++ b/LabBuilder/lib/public/switch.ps1
@@ -395,13 +395,6 @@ function Initialize-LabSwitch {
                         }
                         ThrowException @ExceptionParameters
                     }
-                    elseif ($Adapter | Get-NetIPAddress)
-                    {
-                        $Adapter | Set-NetIPAddress `
-                                -IPAddress $NatGatewayAddress `
-                                -PrefixLength $NatSubnetPrefixLength `
-                                -ErrorAction Stop
-                    }
                     else
                     {
                         $Adapter | New-NetIPAddress `

--- a/LabBuilder/lib/public/switch.ps1
+++ b/LabBuilder/lib/public/switch.ps1
@@ -395,14 +395,20 @@ function Initialize-LabSwitch {
                         }
                         ThrowException @ExceptionParameters
                     }
-                    else
+                    $null = $Adapter | New-NetIPAddress `
+                            -IPAddress $NatGatewayAddress `
+                            -PrefixLength $NatSubnetPrefixLength `
+                            -ErrorAction Stop
+                    # Does the NAT already exist?
+                    $NetNat = Get-NetNat `
+                        -Name $SwitchName `
+                        -ErrorAction SilentlyContinue
+                    if ($NetNat)
                     {
-                        $Adapter | New-NetIPAddress `
-                                -IPAddress $NatGatewayAddress `
-                                -PrefixLength $NatSubnetPrefixLength `
-                                -ErrorAction Stop
-                    } # if
-                    # Convert the Internal switch to a NAT switch
+                        # If the NAT already exists, remove it so it can be recreated
+                        $null = $NetNat | Remove-NetNat
+                    }
+                    # Create the new NAT
                     $null = New-NetNat `
                         -Name $SwitchName `
                         -InternalIPInterfaceAddressPrefix $NatSubnet `

--- a/LabBuilder/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
+++ b/LabBuilder/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<labbuilderconfig xmlns="labbuilderconfig"
+                  name="Sample_WS2012R2_DCandDHCPOnly_NAT"
+                  version="1.0">
+  <description>Sample Windows Server 2012 R2 Lab Configuration DC and DHCP Only and using a NAT virtual switch</description>
+
+  <settings labid="LABBUILDER-NAT.COM"
+            domainname="LABBUILDER-NAT.COM"
+            email="admina@LABBUILDER-NAT.COM"
+            labpath="c:\vm\LABBUILDER-NAT.COM"
+            dsclibrarypath="..\DSCLibrary\" />
+
+  <resources>
+    <msu name="WMF5.0-WS2012R2-W81"
+         url="https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu" />
+  </resources>
+  
+  <switches>
+    <switch name="Domain NAT"
+            type="NAT"
+            vlan="5"
+            natsubnet="192.168.140.0/24" 
+            natgatewayaddress="192.168.140.1" />
+  </switches>
+
+  <templatevhds isopath="ISOFiles" 
+                vhdpath="VHDFiles" 
+                prefix="Template " >
+    <templatevhd name="Windows Server 2012 R2 Datacenter Full"
+                 iso="9600.16384.130821-1623_x64fre_Server_EN-US_IRM_SSS_DV5.iso"
+                 url="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2"
+                 vhd="Windows Server 2012 R2 Datacenter Full.vhdx" 
+                 edition="Windows Server 2012 R2 SERVERDATACENTER" 
+                 ostype="Server"
+                 packages="WMF5.0-WS2012R2-W81"
+                 vhdformat="vhdx" 
+                 vhdtype="dynamic" 
+                 generation="2" 
+                 vhdsize="40GB" />
+    <templatevhd name="Windows Server 2012 R2 Datacenter Core"
+                 iso="9600.16384.130821-1623_x64fre_Server_EN-US_IRM_SSS_DV5.iso"
+                 url="https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012-r2"
+                 vhd="Windows Server 2012 R2 Datacenter Core.vhdx"
+                 edition="Windows Server 2012 R2 SERVERDATACENTERCORE"
+                 ostype="Server"
+                 packages="WMF5.0-WS2012R2-W81"
+                 vhdformat="vhdx" 
+                 vhdtype="dynamic" 
+                 generation="2" 
+                 vhdsize="25GB" />
+  </templatevhds>
+
+  <templates>
+    <template name="Template Windows Server 2012 R2 Datacenter Full"
+              templatevhd="Windows Server 2012 R2 Datacenter FULL"
+              memorystartupbytes="1GB"
+              processorcount="1"
+              administratorpassword="P@ssword!1"
+              timezone="New Zealand Standard Time" 
+              ostype="Server"
+              packages="WMF5.0-WS2012R2-W81" />
+    <template name="Template Windows Server 2012 R2 Datacenter Core"
+              templatevhd="Windows Server 2012 R2 Datacenter CORE"
+              memorystartupbytes="1GB"
+              processorcount="1"
+              administratorpassword="P@ssword!1"
+              timezone="New Zealand Standard Time" 
+              ostype="Server"
+              packages="WMF5.0-WS2012R2-W81" />
+  </templates>
+
+  <vms>
+    <vm name="SA-DC1"
+        template="Template Windows Server 2012 R2 Datacenter CORE"
+        computername="SA-DC1">
+      <dsc configname="DC_FORESTPRIMARY"
+           configfile="DC_FORESTPRIMARY.DSC.ps1">
+        <parameters>
+          DomainName = "LABBUILDER.COM"
+          DomainAdminPassword = "P@ssword!1"
+        </parameters>
+      </dsc>
+      <adapters>
+        <adapter name="Domain Nat"
+                 switchname="Domain Nat">
+          <ipv4 address="192.168.140.10"
+                defaultgateway="192.168.140.1"
+                subnetmask="24"
+                dnsserver="192.168.140.10"/>
+        </adapter>
+      </adapters>
+    </vm>
+
+    <vm name="SA-DHCP1"
+        template="Template Windows Server 2012 R2 Datacenter CORE"
+        computername="SA-DHCP1">
+      <dsc configname="MEMBER_DHCP"
+           configfile="MEMBER_DHCP.DSC.ps1">
+        <parameters>
+          DomainName = "LABBUILDER.COM"
+          DCname = "SA-DC1"
+          DomainAdminPassword = "P@ssword!1"
+          PSDscAllowDomainUser = $True
+          Scopes = @(
+              @{ Name = 'Site A Primary';
+                 Start = '192.168.140.50';
+                 End = '192.168.140.254';
+                 SubnetMask = '255.255.255.0';
+                 AddressFamily = 'IPv4'
+              }
+            )
+          Reservations = @(
+              @{ Name = 'SA-DC1';
+                 ScopeID = '192.168.140.0';
+                 ClientMACAddress = '000000000000';
+                 IPAddress = '192.168.140.10';
+                 AddressFamily = 'IPv4'
+              },
+              @{ Name = 'SA-DHCP1';
+                 ScopeID = '192.168.140.0';
+                 ClientMACAddress = '000000000002';
+                 IPAddress = '192.168.140.16';
+                 AddressFamily = 'IPv4'
+              }
+            )
+          ScopeOptions = @(
+              @{ ScopeID = '192.168.140.0';
+                 DNServerIPAddress = @('192.168.140.10');
+                 Router = '192.168.140.1';
+                 AddressFamily = 'IPv4'
+              }
+            )
+        </parameters>
+      </dsc>
+      <adapters>
+        <adapter name="Domain Nat"
+                 switchname="Domain Nat">
+          <ipv4 address="192.168.140.16"
+                defaultgateway="192.168.140.1"
+                subnetmask="24"
+                dnsserver="192.168.140.10"/>
+        </adapter>
+      </adapters>
+    </vm>
+  </vms>
+
+</labbuilderconfig>

--- a/LabBuilder/schema/labbuilderconfig-schema.xsd
+++ b/LabBuilder/schema/labbuilderconfig-schema.xsd
@@ -358,7 +358,7 @@ It can be set to:
  - Internal
  - Private
  - External
- - NAT (only available on some Windows 10 versions and Windows Server 2016)
+ - NAT (only available on Windows 10 and Windows Server 2016 build 14295 and above)
                       </xs:documentation>
                       <xs:appinfo>type="Internal"</xs:appinfo>
                     </xs:annotation>
@@ -389,6 +389,28 @@ This attribute should only be set if the switch type is External.
 If the bindingadaptername attribute is set then this attribute should not be set.
                       </xs:documentation>
                       <xs:appinfo>bindingadaptermac="C86000A1A895"</xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="natsubnet" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+This optional attribute is used to configure the subnet that will be assigned to this NAT switch.
+It must contain an IP address (192.168.10.0) followed by a slash (/) then the subnet prefix length (e.g. 24).
+This attribute should only be set if the switch type is NAT.
+If this attribute is set the natgatewayaddress attribute must also be set.
+                      </xs:documentation>
+                      <xs:appinfo>natsubnet="192.168.10.0/24"</xs:appinfo>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="natgatewayaddress" type="xs:string" use="optional">
+                    <xs:annotation>
+                      <xs:documentation>
+This optional attribute is used to configure the IP address that will be used as a gateway address on this NAT switch.
+This IP Address must be within the defined NAT subnet set in the natsubnet attribute.
+This attribute should only be set if the switch type is NAT.
+If this attribute is set the natsubnet attribute must also be set.
+                      </xs:documentation>
+                      <xs:appinfo>natgatewayaddress="192.168.10.1"</xs:appinfo>
                     </xs:annotation>
                   </xs:attribute>
                 </xs:complexType>

--- a/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
@@ -40,6 +40,7 @@
     <switch name="Private" type="Private" />
     <switch name="Internal Vlan" type="Internal" vlan="3" />
     <switch name="Internal" type="Internal" />
+    <switch name="NAT" type="NAT" natsubnet="192.168.22.0/24" natgatewayaddress="192.168.22.1"/>
   </switches>
 
   <templatevhds isopath="ISOFiles" 

--- a/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
+++ b/LabBuilder/tests/pestertestconfig/expectedcontent/ExpectedSwitches.json
@@ -3,9 +3,10 @@
         "Name":  "External",
         "Type":  3,
         "VLAN":  0,
-        "NATSubnetAddress":  "",
         "BindingAdapterName":  "Ethernet",
         "BindingAdapterMac":  "",
+        "NatSubnet":  "",
+        "NatGatewayAddress":  "",
         "Adapters":  [
                          {
                              "Name":  "Cluster",
@@ -33,36 +34,50 @@
         "Name":  "TestLab Private Vlan",
         "Type":  1,
         "VLAN":  2,
-        "NATSubnetAddress":  "",
         "BindingAdapterName":  "",
         "BindingAdapterMac":  "",
+        "NatSubnet":  "",
+        "NatGatewayAddress":  "",
         "Adapters":  null
     },
     {
         "Name":  "TestLab Private",
         "Type":  1,
         "VLAN":  0,
-        "NATSubnetAddress":  "",
         "BindingAdapterName":  "",
         "BindingAdapterMac":  "",
+        "NatSubnet":  "",
+        "NatGatewayAddress":  "",
         "Adapters":  null
     },
     {
         "Name":  "TestLab Internal Vlan",
         "Type":  2,
         "VLAN":  3,
-        "NATSubnetAddress":  "",
         "BindingAdapterName":  "",
         "BindingAdapterMac":  "",
+        "NatSubnet":  "",
+        "NatGatewayAddress":  "",
         "Adapters":  null
     },
     {
         "Name":  "TestLab Internal",
         "Type":  2,
         "VLAN":  0,
-        "NATSubnetAddress":  "",
         "BindingAdapterName":  "",
         "BindingAdapterMac":  "",
+        "NatSubnet":  "",
+        "NatGatewayAddress":  "",
+        "Adapters":  null
+    },
+    {
+        "Name":  "TestLab NAT",
+        "Type":  4,
+        "VLAN":  0,
+        "BindingAdapterName":  "",
+        "BindingAdapterMac":  "",
+        "NatSubnet":  "192.168.22.0/24",
+        "NatGatewayAddress":  "192.168.22.1",
         "Adapters":  null
     }
 ]

--- a/LabBuilder/tests/unit/lib/private/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/switch.tests.ps1
@@ -108,8 +108,10 @@ try
             Mock Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 }
             Mock Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged }
 
-            Context 'Switch Management Adapter does not exist, VlanId passed, StaticMacAddress passed' {
+            Context 'Switch Management Adapter does not exist, VlanId not passed, StaticMacAddress not passed' {
                 $Splat = $TestAdapter.Clone()
+                $Splat.Remove('VlanId')
+                $Splat.Remove('StaticMacAddress')
                 It 'Does Not Throw Exception' {
                     { UpdateSwitchManagementAdapter @Splat } | Should Not Throw
                 }
@@ -117,9 +119,43 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
                     Assert-MockCalled Add-VMNetworkAdapter -Exactly 1
                     Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 0
-                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 1
+                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 0
+                }
+            }
+
+            Context 'Switch Management Adapter does not exist, VlanId 10 passed, StaticMacAddress not passed' {
+                $Splat = $TestAdapter.Clone()
+                $Splat.VlanId = 10
+                $Splat.Remove('StaticMacAddress')
+                It 'Does Not Throw Exception' {
+                    { UpdateSwitchManagementAdapter @Splat } | Should Not Throw
+                }
+                It 'Calls Mocked commands' {
+                    Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
+                    Assert-MockCalled Add-VMNetworkAdapter -Exactly 1
+                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 0
                     Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 1
                     Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 0
+                }
+            }
+
+            Context 'Switch Management Adapter does not exist, VlanId null passed, StaticMacAddress not passed' {
+                $Splat = $TestAdapter.Clone()
+                $Splat.VlanId = $null
+                $Splat.Remove('StaticMacAddress')
+                It 'Does Not Throw Exception' {
+                    { UpdateSwitchManagementAdapter @Splat } | Should Not Throw
+                }
+                It 'Calls Mocked commands' {
+                    Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
+                    Assert-MockCalled Add-VMNetworkAdapter -Exactly 1
+                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 0
+                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 1
                 }
             }
 
@@ -135,30 +171,14 @@ try
                     Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 0
                     Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 1
                     Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 0
-                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 1
-                }
-            }
-
-            Context 'Switch Management Adapter does not exist, VlanId not passed, StaticMacAddress not passed' {
-                $Splat = $TestAdapter.Clone()
-                $Splat.Remove('StaticMacAddress')
-                It 'Does Not Throw Exception' {
-                    { UpdateSwitchManagementAdapter @Splat } | Should Not Throw
-                }
-                It 'Calls Mocked commands' {
-                    Assert-MockCalled Get-VMNetworkAdapter -Exactly 1
-                    Assert-MockCalled Add-VMNetworkAdapter -Exactly 1
-                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 1
-                    Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 0
-                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 1
                     Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 0
                 }
             }
 
-            Context 'Switch Management Adapter does not exist, VlanId not passed, StaticMacAddress not passed' {
+            Context 'Switch Management Adapter does not exist, VlanId not passed, empty StaticMacAddress passed' {
                 $Splat = $TestAdapter.Clone()
                 $Splat.Remove('VlanId')
-                $Splat.Remove('StaticMacAddress')
+                $Splat.StaticMacAddress = ''
                 It 'Does Not Throw Exception' {
                     { UpdateSwitchManagementAdapter @Splat } | Should Not Throw
                 }
@@ -168,7 +188,7 @@ try
                     Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $DynamicMacAddress } -Exactly 1
                     Assert-MockCalled Set-VMNetworkAdapter -ParameterFilter { $StaticMacAddress -eq '1234567890AB' } -Exactly 0
                     Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $VlanId -eq 10 } -Exactly 0
-                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 1
+                    Assert-MockCalled Set-VMNetworkAdapterVlan -ParameterFilter { $Untagged } -Exactly 0
                 }
             }
 

--- a/LabBuilder/tests/unit/lib/public/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/switch.tests.ps1
@@ -191,6 +191,13 @@ try
                     $PrefixLength
                 )
             }
+            function New-NetNat {
+                [cmdletbinding()]
+                param (
+                    [String] $Name,
+                    [String] $InternalIPInterfaceAddressPrefix
+                )
+            }
             Mock Get-VMSwitch -MockWith {
                 @{
                     Name = 'Dummy Switch'

--- a/LabBuilder/tests/unit/lib/public/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/switch.tests.ps1
@@ -166,23 +166,7 @@ try
                     [String] $Name
                 )
             }
-            function Get-NetIPAddress {
-                [cmdletbinding()]
-                param (
-                    [Parameter(ValueFromPipeline=$True)]
-                    $InputObject
-                )
-            }
             function New-NetIPAddress {
-                [cmdletbinding()]
-                param (
-                    [Parameter(ValueFromPipeline=$True)]
-                    $InputObject,
-                    [String] $IPAddress,
-                    $PrefixLength
-                )
-            }
-            function Set-NetIPAddress {
                 [cmdletbinding()]
                 param (
                     [Parameter(ValueFromPipeline=$True)]
@@ -208,9 +192,7 @@ try
             Mock Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'Dummy Switch' }
             Mock Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -MockWith { @{ MacAddress = '0012345679A0' } }
             Mock UpdateSwitchManagementAdapter
-            Mock Get-NetIPAddress
             Mock New-NetIPAddress
-            Mock Set-NetIPAddress
             Mock New-NetNat
             Mock Get-NetAdapter -MockWith {
                 @{
@@ -232,9 +214,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 1
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 8
                     Assert-MockCalled Get-NetAdapter -Exactly 3
-                    Assert-MockCalled Get-NetIPAddress -Exactly 1
                     Assert-MockCalled New-NetIPAddress -Exactly 1
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 1
                 }
             }
@@ -250,9 +230,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 1
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 8
                     Assert-MockCalled Get-NetAdapter -Exactly 3
-                    Assert-MockCalled Get-NetIPAddress -Exactly 1
                     Assert-MockCalled New-NetIPAddress -Exactly 1
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 1
                 }
             }
@@ -278,9 +256,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
                 }
             }
@@ -306,9 +282,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
             $Script:CurrentBuild = 14295
@@ -334,9 +308,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
 
@@ -361,9 +333,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
 
@@ -388,9 +358,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
 
@@ -418,9 +386,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 1
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
 
@@ -446,9 +412,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
                 }
             }
@@ -475,9 +439,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 1
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0                }
             }
 
@@ -503,9 +465,7 @@ try
                     Assert-MockCalled Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -Exactly 0
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 1
-                    Assert-MockCalled Get-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled Set-NetIPAddress -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
                 }
             }

--- a/LabBuilder/tests/unit/lib/public/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/switch.tests.ps1
@@ -175,11 +175,24 @@ try
                     $PrefixLength
                 )
             }
+            function Get-NetNat {
+                [cmdletbinding()]
+                param (
+                    [String] $Name
+                )
+            }
             function New-NetNat {
                 [cmdletbinding()]
                 param (
                     [String] $Name,
                     [String] $InternalIPInterfaceAddressPrefix
+                )
+            }
+            function Remove-NetNat {
+                [cmdletbinding()]
+                param (
+                    [Parameter(ValueFromPipeline=$True)]
+                    $InputObject
                 )
             }
             Mock Get-VMSwitch -MockWith {
@@ -193,7 +206,9 @@ try
             Mock Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -MockWith { @{ MacAddress = '0012345679A0' } }
             Mock UpdateSwitchManagementAdapter
             Mock New-NetIPAddress
+            Mock Get-NetNat
             Mock New-NetNat
+            Mock Remove-NetNat
             Mock Get-NetAdapter -MockWith {
                 @{
                     Name       = 'Ethernet'
@@ -215,7 +230,9 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 8
                     Assert-MockCalled Get-NetAdapter -Exactly 3
                     Assert-MockCalled New-NetIPAddress -Exactly 1
+                    Assert-MockCalled Get-NetNat -Exactly 1
                     Assert-MockCalled New-NetNat -Exactly 1
+                    Assert-MockCalled Remove-NetNat -Exactly 0
                 }
             }
 
@@ -231,7 +248,9 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 8
                     Assert-MockCalled Get-NetAdapter -Exactly 3
                     Assert-MockCalled New-NetIPAddress -Exactly 1
+                    Assert-MockCalled Get-NetNat -Exactly 1
                     Assert-MockCalled New-NetNat -Exactly 1
+                    Assert-MockCalled Remove-NetNat -Exactly 0
                 }
             }
 
@@ -257,7 +276,9 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
+                    Assert-MockCalled Get-NetNat -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
                 }
             }
 
@@ -283,7 +304,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
             $Script:CurrentBuild = 14295
 
@@ -309,7 +333,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
 
             Context 'Valid configuration NAT with invalid NAT Subnet Address' {
@@ -334,7 +361,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
 
             Context 'Valid configuration NAT with invalid NAT Subnet Address' {
@@ -359,7 +389,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
 
             Mock Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -MockWith { @{ MacAddress = '' } }
@@ -387,7 +420,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
 
             Mock Get-VMNetworkAdapter -ParameterFilter { $SwitchName -eq 'TestLab NAT' } -MockWith { @{ MacAddress = '001122334455' } }
@@ -413,7 +449,9 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 0
                     Assert-MockCalled New-NetIPAddress -Exactly 0
+                    Assert-MockCalled Get-NetNat -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
                 }
             }
 
@@ -440,7 +478,10 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 1
                     Assert-MockCalled New-NetIPAddress -Exactly 0
-                    Assert-MockCalled New-NetNat -Exactly 0                }
+                    Assert-MockCalled Get-NetNat -Exactly 0
+                    Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
+                }
             }
 
             Context 'Valid configuration with External switch with binding Adapter MAC bad' {
@@ -466,7 +507,9 @@ try
                     Assert-MockCalled UpdateSwitchManagementAdapter -Exactly 0
                     Assert-MockCalled Get-NetAdapter -Exactly 1
                     Assert-MockCalled New-NetIPAddress -Exactly 0
+                    Assert-MockCalled Get-NetNat -Exactly 0
                     Assert-MockCalled New-NetNat -Exactly 0
+                    Assert-MockCalled Remove-NetNat -Exactly 0
                 }
             }
         }


### PR DESCRIPTION
* Fixed support for NAT switches and added Switch attributes NatSubnet and NatGatewayAddress.
* Private function UpdateSwitchManagementAdapter added.
* Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Added sample for testing NAT based Lab switches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/229)
<!-- Reviewable:end -->
