### PR TITLE
Added RequiredWindowsBuild setting support - Fixes #233

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -2,6 +2,8 @@
 * DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Completed DSC Library configuration for installing a SQL Server 2014 from an ISO.
 * Samples\Sample_WS2012R2_DomainSQL2014.xml: Added new Sample for building a simple domain with a SQL Server.
 * Samples\*.xml: DNS Forwarders set to Google for all Samples with Edge nodes.
+* Samples\Sample_WS2012R2_DomainClustering.xml: Required build version set to 10586.
+* Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Required build version set to 14295.
 
 # 0.7.9.0
 * Fixed failure when creating self-signed certificate on localized systems, by replacing EKU Names with IDs.

--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -2,6 +2,8 @@
 * DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Completed DSC Library configuration for installing a SQL Server 2014 from an ISO.
 * Samples\Sample_WS2012R2_DomainSQL2014.xml: Added new Sample for building a simple domain with a SQL Server.
 * Samples\*.xml: DNS Forwarders set to Google for all Samples with Edge nodes.
+* Added LabBuilderConfig\Settings attribute requiredwindowsbuild.
+* Get-Lab: Added support for preventing a Lab from being used on a host not at the requiredwindowsbuild build version. 
 * Samples\Sample_WS2012R2_DomainClustering.xml: Required build version set to 10586.
 * Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Required build version set to 14295.
 

--- a/LabBuilder/docs/labbuilderconfig-schema.md
+++ b/LabBuilder/docs/labbuilderconfig-schema.md
@@ -38,7 +38,8 @@ This required element contains settings attributes controlling general settings 
 > labid="xs:string"
 
 
-This optional attribute contains a Lab Identifier for the Lab. This identifier will be pre-pended to the names of any Virtual Machines, Switches and Network Adapter names created for this Lab.
+This optional attribute contains a Lab Identifier for the Lab.
+This identifier will be pre-pended to the names of any Virtual Machines, Switches and Network Adapter names created for this Lab.
                 
 ``` labid="WS2012R2-CLUSTER-TEST" ```
 
@@ -118,6 +119,17 @@ Once the ADK is installed this setting can be configured to tell LabBuilder wher
 You should not include the DISM.EXE application name in the path.
                 
 ``` resourcepath="C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM\" ```
+
+### 2.9a - REQUIREDWINDOWSBUILD Optional Attribute
+> requiredwindowsbuild="xs:integer"
+
+
+This optional attribute contains the minimum build required on the Lab host to install or use this Lab.
+If the Lab Host does not meet this build number an error will be thrown when loading the Lab configuration.
+This ensures that all features required to install a Lab are available on the Lab Host before installation will proceed.
+If this attribute is not set then the Lab Configuration will be able to installed on any Windows build version Lab Host.
+                
+``` requiredwindowsbuild="14295" ```
 
 ### 3.0e - RESOURCES Optional Element
 

--- a/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
+++ b/LabBuilder/en-us/LabBuilder_LocalizedData.psd1
@@ -8,6 +8,7 @@ ConvertFrom-StringData -StringData @'
     FileExtractError=Error extracting {0}; {1}.
     ConfigurationFileNotFoundError=Configuration file {0} is not found.
     ConfigurationFileEmptyError=Configuration file {0} is empty.
+    RequiredBuildNotMetError=The Windows build of this host '{0}' does not meet the minimum required build of '{1}' to install this Lab.
     ConfigurationFileAlreadyExistsError=Configuration file {0} already exists.
     ConfigurationInvalidError=Configuration is invalid.
     PathNotFoundError={0} path '{1}' is not found.

--- a/LabBuilder/lib/public/lab.ps1
+++ b/LabBuilder/lib/public/lab.ps1
@@ -87,6 +87,20 @@ function Get-Lab {
     $Lab.PreserveWhitespace = $true
     $Lab.LoadXML($Content)
 
+    # Check the Required Windows Build
+    $RequiredWindowsBuild = $Lab.labbuilderconfig.settings.requiredwindowsbuild
+    if ($RequiredWindowsBuild -and `
+        ($Script:CurrentBuild -lt $RequiredWindowsBuild))
+    {
+        $ExceptionParameters = @{
+            errorId = 'RequiredBuildNotMetError'
+            errorCategory = 'InvalidArgument'
+            errorMessage = $($LocalizedData.RequiredBuildNotMetError `
+                -f $Script:CurrentBuild,$RequiredWindowsBuild)
+        }
+        ThrowException @ExceptionParameters
+    } # if
+
     # Figure out the Config path and load it into the XML object (if we can)
     # This path is used to find any additional configuration files that might
     # be provided with config

--- a/LabBuilder/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
+++ b/LabBuilder/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
@@ -3,13 +3,14 @@
 <labbuilderconfig xmlns="labbuilderconfig"
                   name="Sample_WS2012R2_DCandDHCPOnly_NAT"
                   version="1.0">
-  <description>Sample Windows Server 2012 R2 Lab Configuration DC and DHCP Only and using a NAT virtual switch</description>
+  <description>Sample Windows Server 2012 R2 Lab Configuration DC and DHCP Only and using a NAT virtual switch.</description>
 
   <settings labid="LABBUILDER-NAT.COM"
             domainname="LABBUILDER-NAT.COM"
             email="admina@LABBUILDER-NAT.COM"
             labpath="c:\vm\LABBUILDER-NAT.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            dsclibrarypath="..\DSCLibrary\"
+            requiredwindowsbuild="14295" />
 
   <resources>
     <msu name="WMF5.0-WS2012R2-W81"

--- a/LabBuilder/samples/Sample_WS2012R2_DomainClustering.xml
+++ b/LabBuilder/samples/Sample_WS2012R2_DomainClustering.xml
@@ -9,7 +9,8 @@
             domainname="LABBUILDER-DOMAINCLUSTERING.COM"
             email="admin@LABBUILDER-DOMAINCLUSTERING.COM"
             labpath="c:\vm\LABBUILDER-DOMAINCLUSTERING.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            dsclibrarypath="..\DSCLibrary\" 
+            requiredwindowsbuild="10586" />
 
   <resources>
     <msu name="WMF5.0-WS2012R2-W81"

--- a/LabBuilder/schema/labbuilderconfig-schema.xsd
+++ b/LabBuilder/schema/labbuilderconfig-schema.xsd
@@ -22,7 +22,8 @@ This required element contains settings attributes controlling general settings 
             <xs:attribute name="labid" type="xs:string" use="optional">
               <xs:annotation>
                 <xs:documentation>
-This optional attribute contains a Lab Identifier for the Lab. This identifier will be pre-pended to the names of any Virtual Machines, Switches and Network Adapter names created for this Lab.
+This optional attribute contains a Lab Identifier for the Lab.
+This identifier will be pre-pended to the names of any Virtual Machines, Switches and Network Adapter names created for this Lab.
                 </xs:documentation>
                 <xs:appinfo>labid="WS2012R2-CLUSTER-TEST"</xs:appinfo>
               </xs:annotation>
@@ -102,6 +103,17 @@ Once the ADK is installed this setting can be configured to tell LabBuilder wher
 You should not include the DISM.EXE application name in the path.
                 </xs:documentation>
                 <xs:appinfo>resourcepath="C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\DISM\"</xs:appinfo>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="requiredwindowsbuild" type="xs:integer" use="optional">
+              <xs:annotation>
+                <xs:documentation>
+This optional attribute contains the minimum build required on the Lab host to install or use this Lab.
+If the Lab Host does not meet this build number an error will be thrown when loading the Lab configuration.
+This ensures that all features required to install a Lab are available on the Lab Host before installation will proceed.
+If this attribute is not set then the Lab Configuration will be able to installed on any Windows build version Lab Host.
+                </xs:documentation>
+                <xs:appinfo>requiredwindowsbuild="14295"</xs:appinfo>
               </xs:annotation>
             </xs:attribute>
           </xs:complexType>

--- a/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
+++ b/LabBuilder/tests/pestertestconfig/PesterTestConfig.OK.xml
@@ -12,7 +12,8 @@
             vhdparentpath="C:\Pester Lab\Virtual Hard Disk Templates"
             dsclibrarypath="DSCLibrary"
             resourcepath="Resource"
-            dismpath="C:\dism" />
+            dismpath="C:\dism" 
+            requiredwindowsbuild="10560" />
 
   <resources>
     <module name="xNetworking" url="https://github.com/PlagueHO/xNetworking/archive/dev.zip" folder="xNetworking-dev" />

--- a/LabBuilder/tests/unit/lib/public/lab.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/lab.tests.ps1
@@ -119,6 +119,20 @@ try
                     { Get-Lab -ConfigPath 'c:\isempty.xml' } | Should Throw $Exception
                 }
             }
+            $Script:CurrentBuild = 10000
+            Context 'Path is provided and file exists but host build version requirement not met' {
+                It 'Throws RequiredBuildNotMetError Exception' {
+                    $ExceptionParameters = @{
+                        errorId = 'RequiredBuildNotMetError'
+                        errorCategory = 'InvalidArgument'
+                        errorMessage = $($LocalizedData.RequiredBuildNotMetError `
+                            -f $Script:CurrentBuild,'10560')
+                    }
+                    $Exception = GetException @ExceptionParameters
+                    { Get-Lab -ConfigPath $Global:TestConfigOKPath } | Should Throw $Exception
+                }
+            }
+            $Script:CurrentBuild = 10586
         }
 
 


### PR DESCRIPTION
* Added LabBuilderConfig\Settings attribute requiredwindowsbuild.
* Get-Lab: Added support for preventing a Lab from being used on a host not at the requiredwindowsbuild build version. 
* Samples\Sample_WS2012R2_DomainClustering.xml: Required build version set to 10586.
* Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Required build version set to 14295.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/237)
<!-- Reviewable:end -->
