### PR TITLE
*Added InstallRSATTools parameter DSC configurations - Fixes #239

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -9,6 +9,17 @@
 * Added LabBuilderConfig\Resources attribute ISOPath.
 * DSCLibrary\MEMBER.DSC.ps1: Corrected filename.
 * DSCLibrary\MEMBER.DSC.ps1: Fixed Configuration name.
+* Added InstallRSATTools parameter DSC configurations to enable installation of applicable RSAT Management tools:
+  - DC_FORESTCHILDDOMAIN.DSC.ps1
+  - DC_FORESTPRIMARY.DSC.ps1
+  - DC_SECONDARY.DSC.ps1
+  - RODC_SECONDARY.DSC.ps1
+  - MEMBER_DNS.DSC.ps1
+  - MEMBER_DHCPNPAS.DSC.ps1
+  - MEMBER_DHCPDNS.DSC.ps1
+  - MEMBER_DHCP.DSC.ps1
+  - MEMBER_ROOTCA.DSC.ps1
+  - MEMBER_SUBCA.ps1
 
 # 0.7.9.0
 * Fixed failure when creating self-signed certificate on localized systems, by replacing EKU Names with IDs.

--- a/LabBuilder/dsclibrary/DC_FORESTCHILDDOMAIN.DSC.ps1
+++ b/LabBuilder/dsclibrary/DC_FORESTCHILDDOMAIN.DSC.ps1
@@ -12,6 +12,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainName = "DEV"
     DomainAdminPassword = "P@ssword!1"
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     Forwarders = @('8.8.8.8','8.8.4.4')
     ADZones = @(
         @{ Name = 'ALPHA.LOCAL';
@@ -65,6 +66,16 @@ Configuration DC_FORESTCHILDDOMAIN
             Ensure    = "Present"
             Name      = "RSAT-AD-PowerShell"
             DependsOn = "[WindowsFeature]ADDSInstall"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools","RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]ADDSInstall"
+            }
         }
 
         xWaitForADDomain DscDomainWait

--- a/LabBuilder/dsclibrary/DC_FORESTPRIMARY.DSC.ps1
+++ b/LabBuilder/dsclibrary/DC_FORESTPRIMARY.DSC.ps1
@@ -10,6 +10,7 @@ DSC Template Configuration File For use by LabBuilder
 .Parameters:
     DomainName = "LABBUILDER.COM"
     DomainAdminPassword = "P@ssword!1"
+    InstallRSATTools = $True
     Forwarders = @('8.8.8.8','8.8.4.4')
     ADZones = @(
         @{ Name = 'ALPHA.LOCAL';
@@ -63,6 +64,16 @@ Configuration DC_FORESTPRIMARY
             Ensure    = "Present"
             Name      = "RSAT-AD-PowerShell"
             DependsOn = "[WindowsFeature]ADDSInstall"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools","RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]ADDSInstall"
+            }
         }
 
         xADDomain PrimaryDC

--- a/LabBuilder/dsclibrary/DC_SECONDARY.DSC.ps1
+++ b/LabBuilder/dsclibrary/DC_SECONDARY.DSC.ps1
@@ -11,6 +11,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainName = "LABBUILDER.COM"
     DomainAdminPassword = "P@ssword!1"
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     Forwarders = @('8.8.8.8','8.8.4.4')
     ADZones = @(
         @{ Name = 'ALPHA.LOCAL';
@@ -42,21 +43,21 @@ Configuration DC_SECONDARY
 
         WindowsFeature BackupInstall
         { 
-            Ensure = "Present" 
-            Name   = "Windows-Server-Backup" 
+            Ensure = "Present"
+            Name   = "Windows-Server-Backup"
         } 
 
-        WindowsFeature DNSInstall 
+        WindowsFeature DNSInstall
         { 
-            Ensure = "Present" 
-            Name   = "DNS" 
+            Ensure = "Present"
+            Name   = "DNS"
         }
 
-        WindowsFeature ADDSInstall 
+        WindowsFeature ADDSInstall
         {
-            Ensure    = "Present" 
-            Name      = "AD-Domain-Services" 
-            DependsOn = "[WindowsFeature]DNSInstall" 
+            Ensure    = "Present"
+            Name      = "AD-Domain-Services"
+            DependsOn = "[WindowsFeature]DNSInstall"
         }
 
         WindowsFeature RSAT-AD-PowerShellInstall
@@ -66,12 +67,22 @@ Configuration DC_SECONDARY
             DependsOn = "[WindowsFeature]ADDSInstall"
         }
 
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools","RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]ADDSInstall"
+            }
+        }
+
         xWaitForADDomain DscDomainWait
         {
             DomainName           = $Node.DomainName
-            DomainUserCredential = $DomainAdminCredential 
-            RetryCount           = 100 
-            RetryIntervalSec     = 10 
+            DomainUserCredential = $DomainAdminCredential
+            RetryCount           = 100
+            RetryIntervalSec     = 10
             DependsOn            = "[WindowsFeature]ADDSInstall"
         }
 
@@ -79,7 +90,7 @@ Configuration DC_SECONDARY
         {
             DomainName                    = $Node.DomainName
             DomainAdministratorCredential = $DomainAdminCredential
-            SafemodeAdministratorPassword = $LocalAdminCredential 
+            SafemodeAdministratorPassword = $LocalAdminCredential
             DependsOn                     = "[xWaitForADDomain]DscDomainWait"
         }
 

--- a/LabBuilder/dsclibrary/MEMBER_DHCPDNS.DSC.ps1
+++ b/LabBuilder/dsclibrary/MEMBER_DHCPDNS.DSC.ps1
@@ -9,6 +9,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     Scopes = @(
         @{ Name = 'Site A Primary';
             Start = '192.168.128.50';
@@ -74,17 +75,27 @@ Configuration MEMBER_DHCPDNS
             [PSCredential]$DomainAdminCredential = New-Object System.Management.Automation.PSCredential ("$($Node.DomainName)\Administrator", (ConvertTo-SecureString $Node.DomainAdminPassword -AsPlainText -Force))
         }
 
-        WindowsFeature DHCPInstall 
+        WindowsFeature DHCPInstall
         { 
-            Ensure = "Present" 
-            Name   = "DHCP" 
+            Ensure = "Present"
+            Name   = "DHCP"
         }
 
-        WindowsFeature DNSInstall 
+        WindowsFeature DNSInstall
         {
-            Ensure    = "Present" 
-            Name      = "DNS" 
-            DependsOn = "[WindowsFeature]DHCPInstall" 
+            Ensure    = "Present"
+            Name      = "DNS"
+            DependsOn = "[WindowsFeature]DHCPInstall"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-DHCP","RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]DNSInstall"
+            }
         }
 
         WaitForAll DC

--- a/LabBuilder/dsclibrary/MEMBER_DHCPNPAS.DSC.ps1
+++ b/LabBuilder/dsclibrary/MEMBER_DHCPNPAS.DSC.ps1
@@ -11,6 +11,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     Scopes = @(
         @{ Name = 'Site A Primary';
             Start = '192.168.128.50';
@@ -68,17 +69,27 @@ Configuration MEMBER_DHCPNPAS
             [PSCredential]$DomainAdminCredential = New-Object System.Management.Automation.PSCredential ("$($Node.DomainName)\Administrator", (ConvertTo-SecureString $Node.DomainAdminPassword -AsPlainText -Force))
         }
 
-        WindowsFeature NPASPolicyServerInstall 
+        WindowsFeature NPASPolicyServerInstall
         {
-            Ensure = "Present" 
-            Name   = "NPAS-Policy-Server" 
+            Ensure = "Present"
+            Name   = "NPAS-Policy-Server"
         }
 
-        WindowsFeature DHCPInstall 
+        WindowsFeature DHCPInstall
         {
-            Ensure    = "Present" 
-            Name      = "DHCP" 
+            Ensure    = "Present"
+            Name      = "DHCP"
             DependsOn = "[WindowsFeature]NPASPolicyServerInstall"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-DHCP","RSAT-NPAS"
+                DependsOn = "[WindowsFeature]DHCPInstall"
+            }
         }
 
         WaitForAll DC

--- a/LabBuilder/dsclibrary/MEMBER_DNS.DSC.ps1
+++ b/LabBuilder/dsclibrary/MEMBER_DNS.DSC.ps1
@@ -9,6 +9,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     Forwarders = @('8.8.8.8','8.8.4.4')
     PrimaryZones = @(
         @{ Name = 'BRAVO.LOCAL';
@@ -36,6 +37,16 @@ Configuration MEMBER_DNS
         { 
             Ensure = "Present"
             Name   = "DNS"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]DNSInstall"
+            }
         }
 
         WaitForAll DC

--- a/LabBuilder/dsclibrary/MEMBER_ROOTCA.DSC.ps1
+++ b/LabBuilder/dsclibrary/MEMBER_ROOTCA.DSC.ps1
@@ -4,11 +4,12 @@ DSC Template Configuration File For use by LabBuilder
     MEMBER_ROOTCA
 .Desription
     Builds an Enterprise Root CA.
-.Parameters:    
+.Parameters:
     DomainName = "LABBUILDER.COM"
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     CACommonName = "LABBUILDER.COM Root CA"
     CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
     CRLPublicationURLs = "65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
@@ -57,6 +58,16 @@ Configuration MEMBER_ROOTCA
             Ensure = "Present" 
             Name = "Web-Mgmt-Service" 
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools"
+                DependsOn = "[WindowsFeature]ADCSCA"
+            }
         }
 
         if ($Node.InstallOnlineResponder) {

--- a/LabBuilder/dsclibrary/MEMBER_SUBCA.DSC.ps1
+++ b/LabBuilder/dsclibrary/MEMBER_SUBCA.DSC.ps1
@@ -9,6 +9,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
     CACommonName = "LABBUILDER.COM Issuing CA"
     CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
     CRLPublicationURLs = "65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
@@ -48,9 +49,19 @@ Configuration MEMBER_SUBCA
 
         WindowsFeature InstallWebMgmtService
         {
-            Ensure = "Present" 
-            Name = "Web-Mgmt-Service" 
+            Ensure = "Present"
+            Name = "Web-Mgmt-Service"
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools"
+                DependsOn = "[WindowsFeature]ADCSCA"
+            }
         }
 
         if ($Node.InstallOnlineResponder) {

--- a/LabBuilder/dsclibrary/RODC_SECONDARY.DSC.ps1
+++ b/LabBuilder/dsclibrary/RODC_SECONDARY.DSC.ps1
@@ -10,6 +10,7 @@ DSC Template Configuration File For use by LabBuilder
     DomainAdminPassword = "P@ssword!1"
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $True
+    InstallRSATTools = $True
 ###################################################################################################>
 
 Configuration RODC_SECONDARY
@@ -27,21 +28,21 @@ Configuration RODC_SECONDARY
 
         WindowsFeature BackupInstall
         { 
-            Ensure = "Present" 
-            Name   = "Windows-Server-Backup" 
+            Ensure = "Present"
+            Name   = "Windows-Server-Backup"
         }
 
-        WindowsFeature DNSInstall 
+        WindowsFeature DNSInstall
         {
-            Ensure = "Present" 
-            Name   = "DNS" 
+            Ensure = "Present"
+            Name   = "DNS"
         }
 
-        WindowsFeature ADDSInstall 
+        WindowsFeature ADDSInstall
         {
-            Ensure    = "Present" 
-            Name      = "AD-Domain-Services" 
-            DependsOn = "[WindowsFeature]DNSInstall" 
+            Ensure    = "Present"
+            Name      = "AD-Domain-Services"
+            DependsOn = "[WindowsFeature]DNSInstall"
         }
 
         WindowsFeature RSAT-AD-PowerShellInstall
@@ -49,6 +50,16 @@ Configuration RODC_SECONDARY
             Ensure    = "Present"
             Name      = "RSAT-AD-PowerShell"
             DependsOn = "[WindowsFeature]ADDSInstall"
+        }
+
+        if ($InstallRSATTools)
+        {
+            WindowsFeature RSAT-ManagementTools
+            {
+                Ensure    = "Present"
+                Name      = "RSAT-AD-Tools","RSAT-DNS-Server"
+                DependsOn = "[WindowsFeature]ADDSInstall"
+            }
         }
 
         # Wait for the Domain to be available so we can join it.


### PR DESCRIPTION
* Added InstallRSATTools parameter DSC configurations to enable installation of applicable RSAT Management tools:
  - DC_FORESTCHILDDOMAIN.DSC.ps1
  - DC_FORESTPRIMARY.DSC.ps1
  - DC_SECONDARY.DSC.ps1
  - RODC_SECONDARY.DSC.ps1
  - MEMBER_DNS.DSC.ps1
  - MEMBER_DHCPNPAS.DSC.ps1
  - MEMBER_DHCPDNS.DSC.ps1
  - MEMBER_DHCP.DSC.ps1
  - MEMBER_ROOTCA.DSC.ps1
  - MEMBER_SUBCA.ps1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/241)
<!-- Reviewable:end -->
