### PR TITLE
Fix ExposeVirtualizationExtensions when on Windows 10 build 14352 and above - Fixes #251

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -1,5 +1,6 @@
 # Unreleased
 * Added Jenkins build scripts.
+* Fix ExposeVirtualizationExtensions when on Windows 10 build 14352 and above.
 
 # 0.8.3.0
 * Fix bug where Administrator account is not enabled in Windows client OS.

--- a/LabBuilder/lib/public/vm.ps1
+++ b/LabBuilder/lib/public/vm.ps1
@@ -1128,6 +1128,12 @@ function Initialize-LabVM {
             if ($VM.ExposeVirtualizationExtensions `
                 -ne (Get-VMProcessor -VMName $VM.Name).ExposeVirtualizationExtensions)
             {
+                if ($Script:CurrentBuild -ge 14352)
+                {
+                    Set-VMSecurity `
+                        -VMName $VM.Name `
+                        -VirtualizationBasedSecurityOptOut $true
+                } # if
                 # Try and update it
                 Set-VMProcessor `
                     -VMName $VM.Name `


### PR DESCRIPTION
@MS-MatthewWalker - I haven't been able to test this completely yet because I'm not at home tonight so don't have access to my 14352 build machine. I'll try this tomorrow and if it works I'll merge the change to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/252)
<!-- Reviewable:end -->
