### PR TITLE
Support NIC Team as External Switch Network Adapter - Fixes #265

### DIFF
--- a/LabBuilder/docs/changelist.md
+++ b/LabBuilder/docs/changelist.md
@@ -15,8 +15,10 @@
 * DSCLibrary\MEMEBER_DSCPULLSERVER.DSC.ps1: Added DSC Library resource for creating DSC Pull Servers.
 * Added additional logging information when copying DSC Resource modules.
 * Fix bug when copying DSC Resource modules to LabBuilder Files for VM when DSC Modules folder does not exist.
-* Fix bug when copying DSC Resource modules to LabBuilder Files for VM when DSC Modules folder does not exist.
 * DSCLibrary\MEMBER_SQLSERVER2016.DSC.ps1: Added DSC Library configuration for installing a SQL Server 2016 from an ISO.
+* Fix bug using a NIC team as network adapter bound to an external switch.
+* Change AppVeyor script to improve and automate deployment process.
+* Mock functions added to unit tests so that can run on machines without Hyper-V installed.
 
 # 0.8.3.0
 * Fix bug where Administrator account is not enabled in Windows client OS.

--- a/LabBuilder/lib/public/switch.ps1
+++ b/LabBuilder/lib/public/switch.ps1
@@ -27,15 +27,15 @@ function Get-LabSwitch {
             Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         $Lab,
-        
+
         [Parameter(
             Position=2)]
         [ValidateNotNullOrEmpty()]
         [String[]] $Name
     )
 
-    [String] $LabId = $Lab.labbuilderconfig.settings.labid 
-    [LabSwitch[]] $Switches = @() 
+    [String] $LabId = $Lab.labbuilderconfig.settings.labid
+    [LabSwitch[]] $Switches = @()
     $ConfigSwitches = $Lab.labbuilderconfig.Switches.Switch
 
     foreach ($ConfigSwitch in $ConfigSwitches)
@@ -172,7 +172,7 @@ function Initialize-LabSwitch {
             Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         $Lab,
-        
+
         [Parameter(
             Position=2)]
         [ValidateNotNullOrEmpty()]
@@ -189,7 +189,7 @@ function Initialize-LabSwitch {
         [LabSwitch[]] $Switches = Get-LabSwitch `
             @PSBoundParameters
     }
-    
+
     # Create Hyper-V Switches
     foreach ($VMSwitch in $Switches)
     {
@@ -198,7 +198,7 @@ function Initialize-LabSwitch {
             # A names list was passed but this swtich wasn't included
             continue
         } # if
-        
+
         if ((Get-VMSwitch | Where-Object -Property Name -eq $($VMSwitch.Name)).Count -eq 0)
         {
             [String] $SwitchName = $VMSwitch.Name
@@ -221,19 +221,17 @@ function Initialize-LabSwitch {
                     # Determine which Physical Adapter to bind this switch to
                     if ($VMSwitch.BindingAdapterMac)
                     {
-                        $BindingAdapter = Get-NetAdapter `
-                            -Physical | Where-Object {
+                        $BindingAdapter = Get-NetAdapter | Where-Object {
                             ($_.MacAddress -replace '-','') -eq $VMSwitch.BindingAdapterMac
                         }
-                        $ErrorDetail="with a MAC address '$($VMSwitch.BindingAdapterMac)' "
+                        $ErrorDetail = "with a MAC address '$($VMSwitch.BindingAdapterMac)' "
                     }
                     elseif ($VMSwitch.BindingAdapterName)
                     {
                         $BindingAdapter = Get-NetAdapter `
-                            -Physical `
                             -Name $VMSwitch.BindingAdapterName `
                             -ErrorAction SilentlyContinue
-                        $ErrorDetail="with a name '$($VMSwitch.BindingAdapterName)' "
+                        $ErrorDetail = "with a name '$($VMSwitch.BindingAdapterName)' "
                     }
                     else
                     {
@@ -242,7 +240,7 @@ function Initialize-LabSwitch {
                                 ($_.Status -eq 'Up') `
                                 -and (-not $_.Virtual) `
                             } | Select-Object -First 1
-                        $ErrorDetail=''
+                        $ErrorDetail = ''
                     } # if
                     # Check that a Binding Adapter was found
                     if (-not $BindingAdapter)
@@ -269,7 +267,7 @@ function Initialize-LabSwitch {
                             -ErrorAction SilentlyContinue).MacAddress
                     } # foreach
 
-                    $UsedAdapters = @((Get-NetAdapter -Physical | ? {
+                    $UsedAdapters = @((Get-NetAdapter | Where-Object {
                         ($_.MacAddress -replace '-','') -in $MacAddress
                         }).Name)
                     if ($BindingAdapter.Name -in $UsedAdapters)
@@ -439,7 +437,7 @@ function Initialize-LabSwitch {
                     $Splat += @{ VlanId = $VMSwitch.Vlan }
                 } # if
                 UpdateSwitchManagementAdapter @Splat
-            
+
                 # Add any management OS adapters to the switch
                 if ($VMSwitch.Adapters)
                 {

--- a/LabBuilder/lib/public/vmtemplate.ps1
+++ b/LabBuilder/lib/public/vmtemplate.ps1
@@ -4,7 +4,7 @@
 .DESCRIPTION
    Takes the provided Lab and returns the list of Virtul Machine template machines
    that will be used to create the Virtual Machines in this lab.
-   
+
    This list is usually passed to Initialize-LabVMTemplate.
 .PARAMETER Lab
    Contains the Lab object that was loaded by the Get-Lab object.
@@ -49,14 +49,14 @@ function Get-LabVMTemplate {
     {
         [LabVMTemplateVHD[]] $VMTemplateVHDs = Get-LabVMTemplateVHD `
             -Lab $Lab
-    }
+    } # if
 
     [LabVMTemplate[]] $VMTemplates = @()
     [String] $VHDParentPath = $Lab.labbuilderconfig.settings.vhdparentpathfull
-    
+
     # Get a list of all templates in the Hyper-V system matching the phrase found in the fromvm
     # config setting
-    [String] $FromVM=$Lab.labbuilderconfig.templates.fromvm
+    [String] $FromVM = $Lab.labbuilderconfig.templates.fromvm
     if ($FromVM)
     {
         $Templates = @(Get-VM -Name $FromVM)
@@ -120,7 +120,7 @@ function Get-LabVMTemplate {
             # Add the new Template to the Templates Array
             $VMTemplates += @( $VMTemplate )
         } # if
-        
+
         # Determine the Source VHD, Template VHD and VHD
         [String] $SourceVHD = $Template.SourceVHD
         [String] $TemplateVHD = $Template.TemplateVHD
@@ -336,7 +336,7 @@ function Get-LabVMTemplate {
    Contains the Lab object that was loaded by the Get-Lab object.
 .PARAMETER Name
    An optional array of VM Template names.
-   
+
    Only VM Templates matching names in this list will be initialized.
 .PARAMETER VMTemplates
    The array of LabVMTemplate objects pulled from the Lab using Get-LabVMTemplate.
@@ -376,7 +376,7 @@ function Initialize-LabVMTemplate {
             Position=2)]
         [ValidateNotNullOrEmpty()]
         [String[]] $Name,
-        
+
         [Parameter(
             Position=3)]
         [LabVMTemplate[]] $VMTemplates,
@@ -385,7 +385,7 @@ function Initialize-LabVMTemplate {
             Position=4)]
         [LabVMTemplateVHD[]] $VMTemplateVHDs
     )
-    
+
     # if VMTeplates array not passed, pull it from config.
     if (-not $PSBoundParameters.ContainsKey('VMTemplates'))
     {
@@ -394,7 +394,7 @@ function Initialize-LabVMTemplate {
     }
 
     [String] $LabPath = $Lab.labbuilderconfig.settings.labpath
-    
+
     # Check each Parent VHD exists in the Parent VHDs folder for the
     # Lab. If it isn't, try and copy it from the SourceVHD
     # Location.

--- a/LabBuilder/tests/unit/LabBuilder.tests.ps1
+++ b/LabBuilder/tests/unit/LabBuilder.tests.ps1
@@ -89,7 +89,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )

--- a/LabBuilder/tests/unit/lib/private/dsc.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/dsc.tests.ps1
@@ -48,7 +48,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )
@@ -59,11 +59,12 @@ try
                 -ArgumentList $exception, $errorId, $errorCategory, $null
             return $errorRecord
         }
+
         # Run tests assuming Build 10586 is installed
         $Script:CurrentBuild = 10586
 
 
-        Describe 'GetModulesInDSCConfig' {
+        Describe '\Lib\Private\Dsc.ps1\GetModulesInDSCConfig' {
             Context 'Called with Test DSC Resource File' {
                 It 'Returns DSCModules Object that matches Expected Object' {
                     $DSCModules = GetModulesInDSCConfig `
@@ -93,8 +94,8 @@ try
         }
 
 
-        
-        Describe 'SetModulesInDSCConfig' {
+
+        Describe '\Lib\Private\Dsc.ps1\SetModulesInDSCConfig' {
             $Module1 = [LabDSCModule]::New('PSDesiredStateConfiguration','1.0')
             $Module2 = [LabDSCModule]::New('xActiveDirectory')
             $Module3 = [LabDSCModule]::New('xComputerManagement','1.4.0.0')
@@ -111,7 +112,7 @@ try
                     $ExpectedDSCConfig = Get-Content -Path "$Global:ExpectedContentPath\ExpectedDSCConfig.txt"
                     @(Compare-Object `
                         -ReferenceObject $ExpectedDSCConfig `
-                        -DifferenceObject (Get-Content -Path "$Global:ArtifactPath\ExpectedDSCConfig.txt")).Count  | Should Be 0 
+                        -DifferenceObject (Get-Content -Path "$Global:ArtifactPath\ExpectedDSCConfig.txt")).Count  | Should Be 0
                 }
             }
             Context 'Called with Test DSC Resource Content' {
@@ -125,14 +126,17 @@ try
                     $ExpectedDSCConfig = Get-Content -Path "$Global:ExpectedContentPath\ExpectedDSCConfig.txt"
                     @(Compare-Object `
                         -ReferenceObject $ExpectedDSCConfig `
-                        -DifferenceObject (Get-Content -Path "$Global:ArtifactPath\ExpectedDSCConfig.txt")).Count  | Should Be 0 
+                        -DifferenceObject (Get-Content -Path "$Global:ArtifactPath\ExpectedDSCConfig.txt")).Count  | Should Be 0
                 }
             }
         }
 
 
 
-        Describe 'CreateDSCMOFFiles' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Dsc.ps1\CreateDSCMOFFiles' -Tags 'Incomplete' {
+            # Mock functions
+            function Get-VM {}
+            function Get-VMNetworkAdapter {}
 
             Mock Get-VM
 
@@ -140,7 +144,7 @@ try
             [Array]$Switches = Get-LabSwitch -Lab $Lab
             [Array]$Templates = Get-LabVMTemplate -Lab $Lab
             [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
-            
+
             Mock Get-Module
             Mock GetModulesInDSCConfig -MockWith { @('TestModule') }
 
@@ -156,7 +160,7 @@ try
             }
 
             Mock Find-Module
-            
+
             Context 'DSC Module Not Found' {
                 $VM = $VMS[0].Clone()
                 $ExceptionParameters = @{
@@ -179,7 +183,7 @@ try
 
             Mock Find-Module -MockWith { @{ name = 'TestModule' } }
             Mock Install-Module -MockWith { Throw }
-            
+
             Context 'DSC Module Download Error' {
                 $VM = $VMS[0].Clone()
                 $ExceptionParameters = @{
@@ -204,7 +208,7 @@ try
             Mock Test-Path `
                 -ParameterFilter { $Path -like '*TestModule' } `
                 -MockWith { $false }
-            
+
             Context 'DSC Module Not Found in Path' {
                 $VM = $VMS[0].Clone()
                 $ExceptionParameters = @{
@@ -231,7 +235,7 @@ try
                 -MockWith { $true }
             Mock Copy-Item
             Mock Get-LabVMCertificate
-            
+
             Context 'Certificate Create Failed' {
                 $VM = $VMS[0].Clone()
                 $ExceptionParameters = @{
@@ -259,13 +263,13 @@ try
             Mock Import-Certificate
             Mock Get-ChildItem `
                 -ParameterFilter { $path -eq 'cert:\LocalMachine\My' } `
-                -MockWith { @{ 
+                -MockWith { @{
                     FriendlyName = 'DSC Credential Encryption'
-                    Thumbprint = '1FE3BA1B6DBE84FCDF675A1C944A33A55FD4B872'	
+                    Thumbprint = '1FE3BA1B6DBE84FCDF675A1C944A33A55FD4B872'
                 } }
             Mock Remove-Item
             Mock ConfigLCM
-            
+
             Context 'Meta MOF Create Failed' {
                 $VM = $VMS[0].Clone()
                 $ExceptionParameters = @{
@@ -286,7 +290,7 @@ try
                     Assert-MockCalled Install-Module -Exactly 1
                     Assert-MockCalled Copy-Item -Exactly 1
                     Assert-MockCalled Get-LabVMCertificate -Exactly 1
-                    Assert-MockCalled Import-Certificate -Exactly 1			
+                    Assert-MockCalled Import-Certificate -Exactly 1
                     Assert-MockCalled Get-ChildItem -ParameterFilter { $path -eq 'cert:\LocalMachine\My' } -Exactly 1
                     Assert-MockCalled Remove-Item
                     Assert-MockCalled ConfigLCM -Exactly 1
@@ -296,7 +300,11 @@ try
 
 
 
-        Describe 'SetDSCStartFile' {
+        Describe '\Lib\Private\Dsc.ps1\SetDSCStartFile' {
+
+            # Mock functions
+            function Get-VM {}
+            function Get-VMNetworkAdapter {}
 
             Mock Get-VM
 
@@ -348,10 +356,10 @@ try
 
             Mock Get-VMNetworkAdapter -MockWith { @{ Name = 'Exists'; MacAddress = '111111111111' }}
             Mock Set-Content
-            
+
             Context 'Valid Configuration Passed' {
                 $VM = $VMS[0].Clone()
-                
+
                 It 'Does Not Throw Exception' {
                     { SetDSCStartFile -Lab $Lab -VM $VM } | Should Not Throw
                 }
@@ -364,7 +372,7 @@ try
 
 
 
-        Describe 'InitializeDSC' -Tag 'Incomplete' {
+        Describe '\Lib\Private\Dsc.ps1\InitializeDSC' -Tag 'Incomplete' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [LabVM[]] $VMs = Get-LabVM -Lab $Lab
 
@@ -376,7 +384,7 @@ try
 
             Context 'Valid Configuration Passed' {
                 $VM = $VMs[0].Clone()
-                
+
                 It 'Does Not Throw Exception' {
                     { InitializeDSC -Lab $Lab -VM $VM } | Should Not Throw
                 }
@@ -389,11 +397,11 @@ try
 
 
 
-        Describe 'StartDSC' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Dsc.ps1\StartDSC' -Tags 'Incomplete' {
         }
 
 
-        Describe 'GetDSCNetworkingConfig' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Dsc.ps1\GetDSCNetworkingConfig' -Tags 'Incomplete' {
         }
     }
 }

--- a/LabBuilder/tests/unit/lib/private/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/switch.tests.ps1
@@ -48,7 +48,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )
@@ -63,7 +63,7 @@ try
         $Script:CurrentBuild = 10586
 
 
-        Describe 'GetManagementSwitchName' {
+        Describe '\Lib\Private\Switch.ps1\GetManagementSwitchName' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
 
             Context 'Valid Configuration Passed' {
@@ -74,8 +74,8 @@ try
         }
 
 
-        Describe 'UpdateSwitchManagementAdapter' {
-
+        Describe '\Lib\Private\Switch.ps1\UpdateSwitchManagementAdapter' {
+            # Mock functions
             function Set-VMNetworkAdapter {
                 param (
                     [Parameter(ValueFromPipeline=$True)]
@@ -93,6 +93,8 @@ try
                     [Switch] $Access
                 )
             }
+            function Get-VMNetworkAdapter {}
+            function Add-VMNetworkAdapter {}
 
             $TestAdapter = @{
                 Name = 'Adapter Name'
@@ -100,6 +102,7 @@ try
                 VlanId = 10
                 StaticMacAddress = '1234567890AB'
             }
+
 
             Mock Get-VMNetworkAdapter
             Mock Add-VMNetworkAdapter -MockWith { @{ Name = 'Adapter Name'; SwitchName = 'Switch Name' } }

--- a/LabBuilder/tests/unit/lib/private/utils.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/utils.tests.ps1
@@ -64,7 +64,7 @@ try
 
 
 
-        Describe 'DownloadAndUnzipFile' {
+        Describe '\Lib\Private\Utils.ps1\DownloadAndUnzipFile' {
             $URL = 'https://raw.githubusercontent.com/PlagueHO/LabBuilder/dev/LICENSE'
             Context 'Download folder does not exist' {
                 Mock Invoke-WebRequest
@@ -161,12 +161,12 @@ try
 
 
 
-        Describe 'CreateCredential' -Tag 'Incomplete' {
+        Describe '\Lib\Private\Utils.ps1\CreateCredential' -Tag 'Incomplete' {
         }
 
 
 
-        Describe 'DownloadResourceModule' {
+        Describe '\Lib\Private\Utils.ps1\DownloadResourceModule' {
             $URL = 'https://github.com/PowerShell/xNetworking/archive/dev.zip'
 
             Mock Get-Module -MockWith { @( New-Object -TypeName PSObject -Property @{ Name = 'xNetworking'; Version = '2.4.0.0'; } ) }
@@ -518,7 +518,7 @@ try
 
 
 
-        Describe 'InstallHyperV' {
+        Describe '\Lib\Private\Utils.ps1\InstallHyperV' {
 
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
 
@@ -554,7 +554,7 @@ try
 
 
 
-        Describe 'EnableWSMan' {
+        Describe '\Lib\Private\Utils.ps1\EnableWSMan' {
             Context 'WS-Man is already enabled' {
                 Mock Start-Service
                 Mock Get-PSProvider -MockWith { @{ Name = 'wsman' } }
@@ -588,12 +588,12 @@ try
 
 
 
-        Describe 'ValidateConfigurationXMLSchema' -Tag 'Incomplete' {
+        Describe '\Lib\Private\Utils.ps1\ValidateConfigurationXMLSchema' -Tag 'Incomplete' {
         }
 
 
 
-        Describe 'IncreaseMacAddress' {
+        Describe '\Lib\Private\Utils.ps1\IncreaseMacAddress' {
             Context 'MAC address 00155D0106ED is passed' {
                 It 'Returns MAC address 00155D0106EE' {
                     IncreaseMacAddress `
@@ -618,7 +618,7 @@ try
 
 
 
-        Describe 'IncreaseIpAddress' {
+        Describe '\Lib\Private\Utils.ps1\IncreaseIpAddress' {
             Context 'Invalid IP Address is passed' {
                 It 'Throws a IPAddressError Exception' {
                     $ExceptionParameters = @{
@@ -677,7 +677,7 @@ try
 
 
 
-        Describe 'ValidateIpAddress' {
+        Describe '\Lib\Private\Utils.ps1\ValidateIpAddress' {
             Context 'IP address 192.168.1.1 is passed' {
                 It 'Returns True' {
                     ValidateIpAddress `
@@ -706,7 +706,7 @@ try
 
 
 
-        Describe 'InstallPackageProviders' {
+        Describe '\Lib\Private\Utils.ps1\InstallPackageProviders' {
             Context 'Required package providers already installed' {
                 Mock Get-PackageProvider -MockWith {
                     @(
@@ -738,7 +738,7 @@ try
 
 
 
-        Describe 'RegisterPackageSources' {
+        Describe '\Lib\Private\Utils.ps1\RegisterPackageSources' {
             # Define this function because the built in definition does not
             # mock properly - the ProviderName parameter is not definied.
             function Register-PackageSource {

--- a/LabBuilder/tests/unit/lib/private/vhd.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/vhd.tests.ps1
@@ -64,7 +64,7 @@ try
 
 
 
-        Describe 'InitializeBootVHD' {
+        Describe '\Lib\Private\Vhd.ps1\InitializeBootVHD' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [array] $VMs = Get-LabVM -Lab $Lab
             $NanoServerPackagesFolder = Join-Path -Path $Lab.labbuilderconfig.settings.labpath -ChildPath 'NanoServerPackages'
@@ -243,7 +243,11 @@ try
 
 
 
-        Describe 'InitializeVHD' {
+        Describe '\Lib\Private\Vhd.ps1\InitializeVHD' {
+            # Mock functions
+            function Get-VHD {}
+            function Mount-VHD {}
+
             $VHD = @{
                 Path = 'c:\DataVHDx.vhdx'
             }

--- a/LabBuilder/tests/unit/lib/private/vm.tests.ps1
+++ b/LabBuilder/tests/unit/lib/private/vm.tests.ps1
@@ -48,7 +48,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )
@@ -63,43 +63,43 @@ try
         $Script:CurrentBuild = 10586
 
 
-        Describe 'CreateVMInitializationFiles' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Vm.ps1\CreateVMInitializationFiles' -Tags 'Incomplete' {
         }
 
 
-        Describe 'GetUnattendFileContent' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Vm.ps1\GetUnattendFileContent' -Tags 'Incomplete' {
         }
 
 
-        Describe 'GetCertificatePsFileContent' -Tags 'Incomplete' {
-        }
-        
-        
-        Describe 'GetSelfSignedCertificate' -Tags 'Incomplete' {
-        }
-        
-        
-        Describe 'RecreateSelfSignedCertificate' -Tags 'Incomplete' {
-        }
-        
-
-        Describe 'CreateHostSelfSignedCertificate' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Vm.ps1\GetCertificatePsFileContent' -Tags 'Incomplete' {
         }
 
 
-        Describe 'WaitVMInitializationComplete' -Tags 'Incomplete' {
+        Describe '\Lib\Private\Vm.ps1\GetSelfSignedCertificate' -Tags 'Incomplete' {
         }
 
 
-        Describe 'WaitVMStarted' -Tags 'Incomplete'  {
+        Describe '\Lib\Private\Vm.ps1\RecreateSelfSignedCertificate' -Tags 'Incomplete' {
         }
 
 
-        Describe 'WaitVMOff' -Tags 'Incomplete'  {
+        Describe '\Lib\Private\Vm.ps1\CreateHostSelfSignedCertificate' -Tags 'Incomplete' {
         }
 
 
-        Describe 'GetIntegrationServiceNames' {
+        Describe '\Lib\Private\Vm.ps1\WaitVMInitializationComplete' -Tags 'Incomplete' {
+        }
+
+
+        Describe '\Lib\Private\Vm.ps1\WaitVMStarted' -Tags 'Incomplete'  {
+        }
+
+
+        Describe '\Lib\Private\Vm.ps1\WaitVMOff' -Tags 'Incomplete'  {
+        }
+
+
+        Describe '\Lib\Private\Vm.ps1\GetIntegrationServiceNames' {
             #region Mocks
             Mock Get-CimInstance `
                 -ParameterFilter { $Class -eq 'Msvm_VssComponentSettingData' } `
@@ -139,7 +139,10 @@ try
         }
 
 
-        Describe 'UpdateVMIntegrationServices' {
+        Describe '\Lib\Private\Vm.ps1\UpdateVMIntegrationServices' {
+            # Mock functions
+            function Get-VMIntegrationService {}
+
             #region Mocks
             Mock GetIntegrationServiceNames -MockWith {
                 @(
@@ -177,7 +180,7 @@ try
                 [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
                 $VMs[0].IntegrationServices = $null
                 It 'Does not throw an Exception' {
-                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw 
+                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VMIntegrationService -Exactly 1
@@ -190,7 +193,7 @@ try
                 [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
                 $VMs[0].IntegrationServices = ''
                 It 'Does not throw an Exception' {
-                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw 
+                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VMIntegrationService -Exactly 1
@@ -203,7 +206,7 @@ try
                 [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
                 $VMs[0].IntegrationServices = 'VSS'
                 It 'Does not throw an Exception' {
-                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw 
+                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VMIntegrationService -Exactly 1
@@ -215,7 +218,7 @@ try
                 [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
                 $VMs[0].IntegrationServices = 'Guest Service Interface'
                 It 'Does not throw an Exception' {
-                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw 
+                    { UpdateVMIntegrationServices -VM $VMs[0] } | Should Not Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VMIntegrationService -Exactly 1
@@ -226,7 +229,17 @@ try
         }
 
 
-        Describe 'UpdateVMDataDisks' {
+        Describe '\Lib\Private\Vm.ps1\UpdateVMDataDisks' {
+            # Mock functions
+            function Get-VM {}
+            function Get-VHD {}
+            function Resize-VHD {}
+            function New-VHD {}
+            function Get-VMHardDiskDrive {}
+            function Add-VMHardDiskDrive {}
+            function Mount-VHD {}
+            function Dismount-VHD {}
+
             #region Mocks
             Mock Get-VM
             Mock Get-VHD
@@ -236,8 +249,8 @@ try
             Mock New-VHD
             Mock Get-VMHardDiskDrive
             Mock Add-VMHardDiskDrive
-            Mock Test-Path -ParameterFilter { $Path -eq 'DoesNotExist.Vhdx' } -MockWith { $False }        
-            Mock Test-Path -ParameterFilter { $Path -eq 'DoesExist.Vhdx' } -MockWith { $True }        
+            Mock Test-Path -ParameterFilter { $Path -eq 'DoesNotExist.Vhdx' } -MockWith { $False }
+            Mock Test-Path -ParameterFilter { $Path -eq 'DoesExist.Vhdx' } -MockWith { $True }
             Mock InitializeVHD
             Mock Mount-VHD
             Mock Dismount-VHD
@@ -255,7 +268,7 @@ try
             Context 'Valid configuration is passed with no DataVHDs' {
                 $VMs[0].DataVHDs = @()
                 It 'Does not throw an Exception' {
-                    { UpdateVMDataDisks -Lab $Lab -VM $VMs[0] } | Should Not Throw 
+                    { UpdateVMDataDisks -Lab $Lab -VM $VMs[0] } | Should Not Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VHD -Exactly 0
@@ -287,7 +300,7 @@ try
                             -f $VMs[0].Name,$VMs[0].DataVHDs.Vhd,$VMs[0].DataVHDs.VhdType)
                     }
                     $Exception = GetException @ExceptionParameters
-                    { UpdateVMDataDisks -Lab $Lab -VM $VMs[0] } | Should Throw 
+                    { UpdateVMDataDisks -Lab $Lab -VM $VMs[0] } | Should Throw
                 }
                 It 'Calls Mocked commands' {
                     Assert-MockCalled Get-VHD -Exactly 1
@@ -664,7 +677,12 @@ try
 
 
 
-        Describe 'UpdateVMDVDDrives' {
+        Describe '\Lib\Private\Vm.ps1\UpdateVMDVDDrives' {
+            # Mock functions
+            function Get-VMDVDDrive {}
+            function Add-VMDVDDrive {}
+            function Set-VMDVDDrive {}
+
             #region Mocks
             Mock Get-VMDVDDrive
             Mock Add-VMDVDDrive

--- a/LabBuilder/tests/unit/lib/public/lab.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/lab.tests.ps1
@@ -64,7 +64,7 @@ try
         $Script:CurrentBuild = 10586
 
 
-        Describe 'Get-Lab' {
+        Describe '\Lib\Public\Lab.ps1\Get-Lab' {
             Context 'Relative Path is provided and valid XML file exists' {
                 Mock Get-Location -MockWith { @{ Path = $Global:TestConfigPath} }
                 It 'Returns XmlDocument object with valid content' {
@@ -141,12 +141,12 @@ try
 
 
 
-        Describe 'New-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\New-Lab' -Tags 'Incomplete'  {
         }
 
 
 
-        Describe 'Install-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\Install-Lab' -Tags 'Incomplete'  {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
 
             Mock Get-VMSwitch
@@ -171,22 +171,22 @@ try
 
 
 
-        Describe 'Update-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\Update-Lab' -Tags 'Incomplete'  {
         }
 
 
 
-        Describe 'Uninstall-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\Uninstall-Lab' -Tags 'Incomplete'  {
         }
 
 
 
-        Describe 'Start-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\Start-Lab' -Tags 'Incomplete'  {
         }
 
 
 
-        Describe 'Stop-Lab' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Lab.ps1\Stop-Lab' -Tags 'Incomplete'  {
         }
     }
 }

--- a/LabBuilder/tests/unit/lib/public/resource.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/resource.tests.ps1
@@ -64,7 +64,7 @@ try
         $Script:CurrentBuild = 10586
 
 
-        Describe 'Get-LabResourceModule' {
+        Describe '\Lib\Public\Resource.ps1\Get-LabResourceModule' {
 
             Context 'Configuration passed with resource module missing Name.' {
                 It 'Throws a ResourceModuleNameIsEmptyError Exception' {
@@ -93,7 +93,7 @@ try
 
 
 
-        Describe 'Initialize-LabResourceModule' {
+        Describe '\Lib\Public\Resource.ps1\Initialize-LabResourceModule' {
 
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [LabResourceModule[]]$ResourceModules = Get-LabResourceModule -Lab $Lab
@@ -112,7 +112,7 @@ try
 
 
 
-        Describe 'Get-LabResourceMSU' {
+        Describe '\Lib\Public\Resource.ps1\Get-LabResourceMSU' {
 
             Context 'Configuration passed with resource MSU missing Name.' {
                 It 'Throws a ResourceMSUNameIsEmptyError Exception' {
@@ -141,7 +141,7 @@ try
 
 
 
-        Describe 'Initialize-LabResourceMSU' {
+        Describe '\Lib\Public\Resource.ps1\Initialize-LabResourceMSU' {
 
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [LabResourceMSU[]]$ResourceMSUs = Get-LabResourceMSU -Lab $Lab
@@ -161,7 +161,7 @@ try
 
 
 
-        Describe 'Get-LabResourceISO' {
+        Describe '\Lib\Public\Resource.ps1\Get-LabResourceISO' {
 
             Context 'Configuration passed with resource ISO missing Name.' {
                 It 'Throws a ResourceISONameIsEmptyError Exception' {
@@ -238,7 +238,7 @@ try
 
 
 
-        Describe 'Initialize-LabResourceISO' {
+        Describe '\Lib\Public\Resource.ps1\Initialize-LabResourceISO' {
             $Path = "$Global:TestConfigPath\ISOFiles"
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             $Lab.labbuilderconfig.resources.SetAttribute('isopath',$Path)

--- a/LabBuilder/tests/unit/lib/public/switch.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/switch.tests.ps1
@@ -48,7 +48,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )
@@ -64,7 +64,7 @@ try
         $Script:CurrentBuild = 14295
 
 
-        Describe 'Get-LabSwitch' {
+        Describe '\Lib\Public\Switch.ps1\Get-LabSwitch' {
 
             Context 'Configuration passed with switch missing Switch Name.' {
                 It 'Throws a SwitchNameIsEmptyError Exception' {
@@ -152,11 +152,22 @@ try
 
 
 
-        Describe 'Initialize-LabSwitch' {
+        Describe '\Lib\Public\Switch.ps1\Initialize-LabSwitch' {
 
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [LabSwitch[]] $Switches = Get-LabSwitch -Lab $Lab
 
+            # Mock functions
+            function Get-VMSwitch {}
+            function New-VMSwitch {}
+            function Get-VMNetworkAdapter {
+                [cmdletbinding()]
+                param (
+                    [String] $Name,
+                    [String] $SwitchName,
+                    [Switch] $ManagementOS
+                )
+            }
             function Get-NetAdapter {
                 [cmdletbinding()]
                 param (
@@ -516,7 +527,12 @@ try
 
 
 
-        Describe 'Remove-LabSwitch' {
+        Describe '\Lib\Public\Switch.ps1\Remove-LabSwitch' {
+            # Mock functions
+            function Get-VMSwitch {}
+            function Remove-VMSwitch {}
+            function Remove-VMNetworkAdapter {}
+            function Remove-NetNat {}
 
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             [LabSwitch[]] $Switches = Get-LabSwitch -Lab $Lab

--- a/LabBuilder/tests/unit/lib/public/templatevhd.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/templatevhd.tests.ps1
@@ -48,7 +48,7 @@ try
 
                 [Parameter(Mandatory)]
                 [String] $errorMessage,
-                
+
                 [Switch]
                 $terminate
             )
@@ -64,7 +64,7 @@ try
         $Script:CurrentBuild = 10586
 
 
-        Describe 'Get-LabVMTemplateVHD' {
+        Describe '\Lib\Public\TemplateVhd.ps1\Get-LabVMTemplateVHD' {
 
             Context 'Configuration passed with rooted ISO Root Path that does not exist' {
                 It 'Throws a VMTemplateVHDISORootPathNotFoundError Exception' {
@@ -276,7 +276,7 @@ try
             Context 'Valid configuration is passed and template VHD ISOs are found' {
                 It 'Returns VMTemplateVHDs array that matches Expected array' {
                     $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
-                    [Array] $TemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab 
+                    [Array] $TemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab
                     # Remove the VHDPath and ISOPath values for any VMtemplatesVHD
                     #  because they will usually be relative to the test folder and
                     # won't exist on any other test system
@@ -294,7 +294,7 @@ try
 
 
 
-        Describe 'Initialize-LabVMTemplateVHD' {
+        Describe '\Lib\Public\TemplateVhd.ps1\Initialize-LabVMTemplateVHD' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             $ResourceMSUFile = Join-Path -Path $Lab.labbuilderconfig.settings.resourcepathfull -ChildPath "Win8.1AndW2K12R2-KB3134758-x64.msu"
 
@@ -320,7 +320,7 @@ try
             Mock Get-WindowsImage -MockWith { @{ ImageName = 'DOESNOTMATTER' } }
             Mock Copy-Item
             Mock Rename-Item
-            
+
             # Mock Convert-WindowsImage
             if (-not (Test-Path -Path Function:Convert-WindowsImage))
             {
@@ -507,7 +507,7 @@ try
             $NanoServerPackagesFolder = Join-Path `
                     -Path (Split-Path -Path $VMTemplateVHDs[5].vhdpath -Parent) `
                     -ChildPath 'NanoServerPackages'
-            
+
             Context 'Valid Configuration Passed with Nano Server VHDx not generated and two packages' {
                 Mock Test-Path -ParameterFilter { $Path -eq $NanoServerPackagesFolder } -MockWith { $True }
                 Mock Test-Path -ParameterFilter { $Path -like "$NanoServerPackagesFolder\*.cab" } -MockWith { $True }
@@ -597,7 +597,7 @@ try
         }
 
 
-        Describe 'Remove-LabVMTemplateVHD' {
+        Describe '\Lib\Public\TemplateVhd.ps1\Remove-LabVMTemplateVHD' {
             $Lab = Get-Lab -ConfigPath $Global:TestConfigOKPath
             $VMTemplateVHDs = Get-LabVMTemplateVHD -Lab $Lab
             Mock Remove-Item

--- a/LabBuilder/tests/unit/lib/public/vm.tests.ps1
+++ b/LabBuilder/tests/unit/lib/public/vm.tests.ps1
@@ -60,7 +60,9 @@ try
             return $errorRecord
         }
 
-        Describe 'Get-LabVM' {
+        Describe '\Lib\Public\Vm.ps1\Get-LabVM' {
+            # Mock functions
+            function Get-VM {}
 
             #region mocks
             Mock Get-VM
@@ -670,7 +672,7 @@ try
 
 
 
-        Describe 'Initialize-LabVM'  -Tags 'Incomplete' {
+        Describe '\Lib\Public\Vm.ps1\Initialize-LabVM'  -Tags 'Incomplete' {
             #region Mocks
             Mock New-VHD
             Mock New-VM
@@ -721,7 +723,12 @@ try
 
 
 
-        Describe 'Remove-LabVM' {
+        Describe '\Lib\Public\Vm.ps1\Remove-LabVM' {
+            # Mock functions
+            function Get-VM {}
+            function Stop-VM {}
+            function Remove-VM {}
+
             #region Mocks
             Mock Get-VM -MockWith { [PSObject]@{ Name = 'TestLab PESTER01'; State = 'Running'; } }
             Mock Stop-VM
@@ -786,7 +793,7 @@ try
 
 
 
-        Describe 'Install-LabVM' -Tags 'Incomplete' {
+        Describe '\Lib\Public\Vm.ps1\Install-LabVM' -Tags 'Incomplete' {
             #region Mocks
             Mock Get-VM -ParameterFilter { $Name -eq 'PESTER01' } -MockWith { [PSObject]@{ Name='PESTER01'; State='Off' } }
             Mock Get-VM -ParameterFilter { $Name -eq 'pester template *' }
@@ -826,12 +833,12 @@ try
 
 
 
-        Describe 'Connect-LabVM' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Vm.ps1\Connect-LabVM' -Tags 'Incomplete'  {
         }
 
 
 
-        Describe 'Disconnect-LabVM' -Tags 'Incomplete'  {
+        Describe '\Lib\Public\Vm.ps1\Disconnect-LabVM' -Tags 'Incomplete'  {
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,11 +41,11 @@ install:
         $manifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', $newVersion
         Set-Content -Path $ManifestPath -Value $ManifestContent
 
-        # Set the new version number in the Readme.md
-        $readmePath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'labbuilder\docs\changelist.md'
-        $readmeContent = Get-Content -Path $readmePath -Raw
-        $readmeContent = $readmeContent -replace '### Unreleased', "### $newVersion"
-        Set-Content -Path $readmePath -Value $readmeContent
+        # Set the new version number in the Changelist.md
+        $changeListPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'labbuilder\docs\changelist.md'
+        $changeListContent = Get-Content -Path $changeListPath -Raw
+        $changeListContent = $changeListContent -replace '# Unreleased', "# $newVersion"
+        Set-Content -Path $changeListPath -Value $changeListContent
 
         Install-WindowsFeature -Name hyper-v-powershell
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,11 @@ install:
   - ps: |
         Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
         Install-Module -Name Pester -Repository PSGallery -Force
+        Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Force
 
         # Update AppVeyor Build Version by pulling from Manifest
         $ManifestPath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'LabBuilder\LabBuilder.psd1'
         $ManifestContent = Get-Content -Path $ManifestPath -Raw
-
         $Regex = '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')'
         $Matches = @([regex]::matches($ManifestContent, $Regex, 'IgnoreCase'))
         $version = $null
@@ -22,15 +22,30 @@ install:
             $version = $Matches[0].Value
         }
 
-        # new version
-        $version = "$version.$env:APPVEYOR_BUILD_NUMBER"
+        # Determine the new version number
+        $versionArray = $version -split '\.'
+        $newVersion = ''
+        Foreach ($ver in (0..2)) {
+            $sem = $versionArray[$ver]
+            if ([String]::IsNullOrEmpty($sem)) {
+                $sem = '0'
+            }
+            $newVersion += "$sem."
+        }
+        $newVersion += $env:APPVEYOR_BUILD_NUMBER
 
         # update AppVeyor build
-        Update-AppveyorBuild -Version $version
+        Update-AppveyorBuild -Version $newVersion
 
-        # Set version number
-        $ManifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', ('${{ModuleVersion}}.{0}' -f $env:APPVEYOR_BUILD_NUMBER)
+        # Set the new version number in the Module Manifest
+        $manifestContent = $ManifestContent -replace '(?<=ModuleVersion\s+=\s+'')(?<ModuleVersion>.*)(?='')', $newVersion
         Set-Content -Path $ManifestPath -Value $ManifestContent
+
+        # Set the new version number in the Readme.md
+        $readmePath = Join-Path -Path $ENV:APPVEYOR_BUILD_FOLDER -ChildPath 'labbuilder\docs\changelist.md'
+        $readmeContent = Get-Content -Path $readmePath -Raw
+        $readmeContent = $readmeContent -replace '### Unreleased', "### $newVersion"
+        Set-Content -Path $readmePath -Value $readmeContent
 
         Install-WindowsFeature -Name hyper-v-powershell
 
@@ -89,30 +104,68 @@ deploy_script:
         $null = Add-Type -assemblyname System.IO.Compression.FileSystem
         [System.IO.Compression.ZipFile]::CreateFromDirectory($StagingFolder, $zipFilePath)
 
+        # Remove the Staging folder
+        $null = Remove-Item -Path $StagingFolder -Recurse -Force
+
         # Create Publish Script Artifact
         $PublishScriptName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + "_publish.ps1"
         $PublishScriptPath = Join-Path -Path $buildFolder -ChildPath $PublishScriptName
         Set-Content -Path $PublishScriptPath -Value "Publish-Module -Name 'LabBuilder' -RequiredVersion ${env:APPVEYOR_BUILD_VERSION} -NuGetApiKey (Read-Host -Prompt 'NuGetApiKey')"
-
         @(
             # You can add other artifacts here
             $zipFilePath,
-            $PublishScriptPath
+            $PublishScriptPath,
+            $testResultsFile
         ) | % {
             Write-Host "Pushing package $_ as Appveyor artifact"
             Push-AppveyorArtifact $_
+            Remove-Item -Path $_ -Force
         }
 
         # If this is a build of the Master branch and not a PR push
         # then publish the Module to the PowerShell Gallery.
-        if ((! $ENV:APPVEYOR_PULL_REQUEST_NUMBER) `
-            -and ($ENV:APPVEYOR_REPO_BRANCH -eq 'master'))
-        {
-            Write-Host "Publishing Module to PowerShell Gallery"
-            Copy-Item -Path $ModuleFolder -Destination ($ENV:PSModulePath -split ';')[0] -Recurse
-            Get-PackageProvider -Name NuGet -ForceBootstrap
-            Publish-Module -Name 'LabBuilder' -RequiredVersion ${ENV:APPVEYOR_BUILD_VERSION} -NuGetApiKey $ENV:PowerShellGalleryApiKey -Confirm:$false
-        }
+        # Deployment management
+        if ($ENV:APPVEYOR_REPO_BRANCH -eq 'master') {
+            if ($ENV:APPVEYOR_PULL_REQUEST_NUMBER) {
+                # This is a PR so do nothing
+            } elseif ($ENV:APPVEYOR_REPO_COMMIT_MESSAGE -like '* Deploy!') {
+                # This was a deploy commit so no need to do anything
+            } else {
+                # This is not a PR so deploy
+                Write-Host "Beginning deploy process"
 
-        # Remove Staging Folder
-        $null = Remove-Item -Path $StagingFolder -Recurse -Force
+                # Pull the master branch, update the readme.md and manifest
+                Set-Location -Path $ENV:APPVEYOR_BUILD_FOLDER
+                & git @('config','--global','credential.helper','store')
+                Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:GitHubPushFromPlagueHO):x-oauth-basic@github.com`n"
+                & git @('config','--global','user.email','plagueho@gmail.com')
+                & git @('config','--global','user.name','Daniel Scott-Raynsford')
+
+                & git @('checkout','-f','master')
+                Set-Content -Path $ManifestPath -Value $ManifestContent
+                Set-Content -Path $readmePath -Value $readmeContent
+
+                # Update the master branch
+                Write-Host "Pushing deployment changes to Master"
+                & git @('add','.')
+                & git @('commit','-m',"$NewVersion Deploy!")
+                & git @('status')
+                & git @('push','origin','master')
+
+                # Create the version tag and push it
+                Write-Host "Pushing $newVersion tag to Master"
+                & git @('tag','-a',$newVersion,'-m',$newVersion)
+                & git @('push','origin',$newVersion)
+
+                # Merge the changes to the Dev branch as well
+                Write-Host "Pushing deployment changes to Dev"
+                & git @('checkout','-f','dev')
+                & git @('merge','master')
+                & git @('push','origin','dev')
+
+                # This is a commit to Master
+                Write-Host "Publishing Module to PowerShell Gallery"
+                Get-PackageProvider -Name NuGet -ForceBootstrap
+                Publish-Module -Name 'LabBuilder' -RequiredVersion $newVersion -NuGetApiKey $ENV:PowerShellGalleryApiKey -Confirm:$false
+            }
+        }


### PR DESCRIPTION
* Fix bug using a NIC team as network adapter bound to an external switch.
* Change AppVeyor script to improve and automate deployment process.
* Mock functions added to unit tests so that can run on machines without Hyper-V installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/266)
<!-- Reviewable:end -->
