### PR TITLE
General Improvements & Fixes to DSC Configurations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD029": {
+        "style": "one"
+    },
+    "MD013": true,
+    "MD024": true,
+    "MD034": true,
+    "no-hard-tabs": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## Unreleased
+
+- `DSCLibrary\MEMBER_SUBCA.DSC.ps1`:
+  - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
+  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
+    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
+- `DSCLibrary\MEMBER_ROOTCA.DSC.ps1`:
+  - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
+  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
+    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
+  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
+    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
+  - Changed CApolicy.inf RenewalKeyLength to 4096, CNGHashAlgorithm to SHA256 and
+    LoadDefaultTemplates to 0 - fixes [Issue-324](https://github.com/PlagueHO/LabBuilder/issues/324).
+- `DSCLibrary\STANDALONE_ROOTCA.DSC.ps1`:
+  - Correct SubCA resource name to wait for - fixes [Issue-321](https://github.com/PlagueHO/LabBuilder/issues/321).
+  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
+    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
+  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
+    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
+- `DSCLibrary\STANDALONE_ROOTCA_NOSUBCA.DSC.ps1`:
+  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
+    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
+  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
+    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
+- Added `.markdownlint.json` file.
+- Fix markdown rule violations in `CHANGELOG.MD`.
+
 ## 1.0.2.58
 
 - Reword module description in Manifest.
@@ -89,34 +117,40 @@
 
 ## 0.8.3.1132
 
-- Added .vscode\settings.json to force code styles and enable auto formatting in VS Code.
-- Changed WaitVMStarted to check VM is running and also handle blank heartbeat being returned
-  in Windows 10 15063 (Creators Update) and above.
+- Added .vscode\settings.json to force code styles and enable auto formatting in
+  VS Code.
+- Changed WaitVMStarted to check VM is running and also handle blank heartbeat
+  being returned in Windows 10 15063 (Creators Update) and above.
 - Updated LabBuilder to support changes in xNetworking DSC Resource v5.0.0.0
 - Updated DSC sample configurations to support xStorage DSC Resource v3.2.0.0
 
 ## 0.8.3.1124
 
-- DSCLibrary\MEMBER_DHCPNPAS2016.DSC.ps1:Added DSC Library Configuration for DHCP with NPAS on
-  Windows Server 2016 - see [Issue 283](https://github.com/PlagueHO/LabBuilder/issues/283).
+- DSCLibrary\MEMBER_DHCPNPAS2016.DSC.ps1:Added DSC Library Configuration for
+  DHCP with NPAS on Windows Server 2016 - see [Issue 283](https://github.com/PlagueHO/LabBuilder/issues/283).
 
 ## 0.8.3.1116
 
 - Moved Changelist.md file to root and renamed to CHANGELOG.MD.
 - Cleaned up markdown errors in README.MD.
 - Updated samples to use latest version of Windows Server 2016 Evaulation ISO.
-- Added sample Sample_WS2016_DomainFunctions.xml for creating an Azure Functions lab.
+- Added sample Sample_WS2016_DomainFunctions.xml for creating an Azure Functions
+  lab.
 - Added support for codecoverage analysis using CodeCov.io.
 
 ## 0.8.3.1107
 
-- DSCLibrary\MEMBER_CONTAINER_HOST.DSC.ps1: Added DSC Configuration for configuring a Docker Container host.
-- Added support for inserting ODJ files into a VM for joining Nano Servers to an AD domain.
+- DSCLibrary\MEMBER_CONTAINER_HOST.DSC.ps1: Added DSC Configuration for configuring
+  a Docker Container host.
+- Added support for inserting ODJ files into a VM for joining Nano Servers to an
+  AD domain.
 - Fix error occuring when starting DSC on node with no adapters.
-- LabDSCModule class: Added [Version] MinimuVersion property, converted ModuleVersion property to [Version].
+- LabDSCModule class: Added [Version] MinimuVersion property, converted ModuleVersion
+  property to [Version].
 - Corrected format of Changelist.md.
 - Change SubnetMask to PrefixLength in xIPAdress DSC Config created by Get-LabDSCNetworkingConfig.
-- Added support for specifying minimum module version in Update-LabDSC to enforce xNetworking 3.0.0.0 usage.
+- Added support for specifying minimum module version in Update-LabDSC to enforce
+  xNetworking 3.0.0.0 usage.
 
 ## 0.8.3.1068
 
@@ -132,18 +166,24 @@
 - Fixed issue with Shared VHDX that prevented their creation.
 - Updated SCHEMA for information on Version and Generation
 - Fixed several typos in comment sections
-- DSC resources created for working with composite DSC resources - non-functional at this time
+- DSC resources created for working with composite DSC resources - non-functional
+  at this time
 - Correctly enable PS Remoting using Enable-PSRemoting cmdlet.
-- DSCLibrary\MEMEBER_DSCPULLSERVER.DSC.ps1: Added DSC Library resource for creating DSC Pull Servers.
+- DSCLibrary\MEMEBER_DSCPULLSERVER.DSC.ps1: Added DSC Library resource for
+  creating DSC Pull Servers.
 - Added additional logging information when copying DSC Resource modules.
-- Fix bug when copying DSC Resource modules to LabBuilder Files for VM when DSC Modules folder does not exist.
-- DSCLibrary\MEMBER_SQLSERVER2016.DSC.ps1: Added DSC Library configuration for installing a SQL Server 2016 from an ISO.
+- Fix bug when copying DSC Resource modules to LabBuilder Files for VM when DSC
+  Modules folder does not exist.
+- DSCLibrary\MEMBER_SQLSERVER2016.DSC.ps1: Added DSC Library configuration for
+  installing a SQL Server 2016 from an ISO.
 - Fix bug using a NIC team as network adapter bound to an external switch.
 - Change AppVeyor script to improve and automate deployment process.
-- Mock functions added to unit tests so that can run on machines without Hyper-V installed.
+- Mock functions added to unit tests so that can run on machines without Hyper-V
+  installed.
 - Added Windows Server 2016 sample labs.
 - Removed old Lab test scripts and replaced with a single Lab test script ```Invoke-LabSample.ps1```.
-- Updated all samples to use the filename of the latest Windows Server 2012 R2 Evaluation ISO.
+- Updated all samples to use the filename of the latest Windows Server 2012 R2
+  Evaluation ISO.
 
 ## 0.8.3.0
 
@@ -152,7 +192,8 @@
 
 ## 0.8.2.0
 
-- Fix bug when creating a new Management adapter for a new Lab and setting a static MAC address on it.
+- Fix bug when creating a new Management adapter for a new Lab and setting a
+  static MAC address on it.
 
 ## 0.8.1.0
 
@@ -161,17 +202,21 @@
 
 ## 0.8.0.0
 
-- DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Completed DSC Library configuration for installing a SQL Server 2014 from an ISO.
-- Samples\Sample_WS2012R2_DomainSQL2014.xml: Added new Sample for building a simple domain with a SQL Server.
+- DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Completed DSC Library configuration
+  for installing a SQL Server 2014 from an ISO.
+- Samples\Sample_WS2012R2_DomainSQL2014.xml: Added new Sample for building a
+  simple domain with a SQL Server.
 - Samples\*.xml: DNS Forwarders set to Google for all Samples with Edge nodes.
 - Added LabBuilderConfig\Settings attribute requiredwindowsbuild.
-- Get-Lab: Added support for preventing a Lab from being used on a host not at the requiredwindowsbuild build version.
+- Get-Lab: Added support for preventing a Lab from being used on a host not at
+  the requiredwindowsbuild build version.
 - Samples\Sample_WS2012R2_DomainClustering.xml: Required build version set to 10586.
 - Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Required build version set to 14295.
 - Added LabBuilderConfig\Resources attribute ISOPath.
 - DSCLibrary\MEMBER.DSC.ps1: Corrected filename.
 - DSCLibrary\MEMBER.DSC.ps1: Fixed Configuration name.
-- Added InstallRSATTools parameter DSC configurations to enable installation of applicable RSAT Management tools:
+- Added InstallRSATTools parameter DSC configurations to enable installation of
+  applicable RSAT Management tools:
   - DC_FORESTCHILDDOMAIN.DSC.ps1
   - DC_FORESTPRIMARY.DSC.ps1
   - DC_SECONDARY.DSC.ps1
@@ -185,31 +230,44 @@
 
 ## 0.7.9.0
 
-- Fixed failure when creating self-signed certificate on localized systems, by replacing EKU Names with IDs.
-- Fixed support for NAT switches and added Switch attributes NatSubnet and NatGatewayAddress.
+- Fixed failure when creating self-signed certificate on localized systems, by
+  replacing EKU Names with IDs.
+- Fixed support for NAT switches and added Switch attributes NatSubnet and
+  NatGatewayAddress.
 - Private function UpdateSwitchManagementAdapter added.
-- Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Added sample for testing NAT based Lab switches.
+- Samples\Sample_WS2012R2_DCandDHCPOnly_NAT.xml: Added sample for testing NAT
+  based Lab switches.
 - Improved ShouldProcess messages to be easier to read.
-- Utils\Install-LabPackageProvider: Added function for ensuring Package Providers are installed.
-- Utils\Register-LabPackageSource: Added function for ensuring Package surces are registered.
-- Install-Lab: Added checks to ensure required PackageProviders and PackageSources are available.
+- Utils\Install-LabPackageProvider: Added function for ensuring Package Providers
+  are installed.
+- Utils\Register-LabPackageSource: Added function for ensuring Package surces
+  are registered.
+- Install-Lab: Added checks to ensure required PackageProviders and PackageSources
+  are available.
 
 ## 0.7.8.0
 
-- Install-Lab: Force flag added to suppress confirmation messages.
-               Will attempt to install WS-Man if not installed, failure will cause install to fail.
-- Disconnect-LabVM: Improve handling of adding IPAddress to trusted hosts.
-- Get-LabVM: LabID will only be prepended to VM Adapter name for adapters not attached to an External switch.
+- Install-Lab:
+  - Force flag added to suppress confirmation messages.
+  - Will attempt to install WS-Man if not installed, failure will
+    cause install to fail.
+- Disconnect-LabVM:
+  - Improve handling of adding IPAddress to trusted hosts.
+- Get-LabVM:
+  - LabID will only be prepended to VM Adapter name for adapters not
+    attached to an External switch.
 
 ## 0.7.7.0
 
-- Samples\Sample_WS2016TP5_DCandDHCPOnly.xml: Set edition in Nano Server Template VHD.
-                                              Fixed WS2016 Template VHD edition names.
-                                              Fixed Template name.
+- Samples\Sample_WS2016TP5_DCandDHCPOnly.xml:
+  - Set edition in Nano Server Template VHD.
+  - Fixed WS2016 Template VHD edition names.
+  - Fixed Template name.
 
 ## 0.7.6.0
 
-- Added .vscode\tasks.json file to allow quick conversion of LabBuilder Schema to MD.
+- Added .vscode\tasks.json file to allow quick conversion of LabBuilder Schema
+  to MD.
 - Moved existing Libs into Libs\Private folder.
 - Updated samples and tests to support Windows Server 2016 TP5.
 - Updated Visual Studio Project and Soltion files.
@@ -219,57 +277,80 @@
 
 - Added VM InstanceCount attribute for creating multiple copies a VM in a Lab.
 - Added $Script:CurrentBuild variable to allow easier access to OS build version.
-- Fix to prevent ExposeVirtualizationExtensions from being applied on Lab Hosts that don't support it.
-- Samples\Sample_WS2012R2_DCandDHCPandEdge.ps1: Added sample for creating Lab with DC, DHCP and Edge servers.
-- DSCLibrary\MEMBER_JENKINS.DSC.ps1: Added DSC Library configuration for creating a Domain Joined Jenkins CI Server.
-- DSCLibrary\STANDALONE_JENKINS.DSC.ps1: Added DSC Library configuration for creating a Standalone Jenkins CI Server.
+- Fix to prevent ExposeVirtualizationExtensions from being applied on Lab Hosts
+  that don't support it.
+- Samples\Sample_WS2012R2_DCandDHCPandEdge.ps1: Added sample for creating Lab with
+  DC, DHCP and Edge servers.
+- DSCLibrary\MEMBER_JENKINS.DSC.ps1: Added DSC Library configuration for creating
+  a Domain Joined Jenkins CI Server.
+- DSCLibrary\STANDALONE_JENKINS.DSC.ps1: Added DSC Library configuration for
+  creating a Standalone Jenkins CI Server.
 - Install-Lab will now stop if error occurs creating Lab Management switch or adapter.
 - Added support for Get-Lab to work with config files with a relative path.
-- Improved handling of Initialize-LabSwitches when Multiple External adapters are available and/or already in use by external switches.
+- Improved handling of Initialize-LabSwitches when Multiple External adapters are
+  available and/or already in use by external switches.
 - Improved Localization support for Integration Services.
 
 ## 0.7.4.0
 
-- lib\vm.ps1: WaitWMStarted - name of integrationservice "heartbeat" detected by id to be culture neutral
+- lib\vm.ps1: WaitWMStarted - name of integrationservice "heartbeat" detected by
+  id to be culture neutral
 - DSCLibrary\MEMBER_ADFS.DSC.ps1: Enable ADFS Firewall Rules.
 - AppVeyor.yml: Module Manifest version number always set to match build version.
 - DSCLibrary\MEMBER_IPAM.DSC.ps1:Added DSC Library Configuration for IPAM Server.
-- DSCLibrary\MEMBER_FAILOVERCLUSTER_*.DSC.ps1: Added iSCSI Firewall Rules to allow iSNS registration.
+- DSCLibrary\MEMBER_FAILOVERCLUSTER_*.DSC.ps1: Added iSCSI Firewall Rules to allow
+  iSNS registration.
 - DSCLibrary\MEMBER_ADFS.DSC.ps1: Added DSC Library configuration for ADRMS.
-- DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Added Incomplete DSC Library configuration for SQL Server 2014.
-- Support\Convert-WindowsImage.ps1: Updated to March 2016 version so that DISM path can be specified.
-- labbuilder-schema.xsd: Added Settings\DismPath attribute so that path to DISM can be specified.
+- DSCLibrary\MEMBER_SQLSERVER2014.DSC.ps1: Added Incomplete DSC Library configuration
+  for SQL Server 2014.
+- Support\Convert-WindowsImage.ps1: Updated to March 2016 version so that DISM
+  path can be specified.
+- labbuilder-schema.xsd: Added Settings\DismPath attribute so that path to DISM
+  can be specified.
 - Failure to validate Lab configuration XML will terminate any cmdlet immediately.
 - Any failure in Install-Lab will cause immediate build termination.
-- Support\Convert-WindowsImage.ps1: Fixed incorrect error reported when invalid Edition is specified.
+- Support\Convert-WindowsImage.ps1: Fixed incorrect error reported when invalid
+  Edition is specified.
 - SetModulesInDSCConfig: Ensure each Import-DSCResource ends up on a new line.
-- DSCLibrary\MEMBER_NANO.DSC.ps1: Added DSC Library configuration for joining a Nano server to n AD Domain.
+- DSCLibrary\MEMBER_NANO.DSC.ps1: Added DSC Library configuration for joining a
+  Nano server to n AD Domain.
 - labbuilder-schema.xsd: Fixed VM attribute descriptions.
-- Added CertificateSource attribute to VM to support controlling where any Lab Certificates should be generated from when initializing a Lab VM.
+- Added CertificateSource attribute to VM to support controlling where any Lab
+  Certificates should be generated from when initializing a Lab VM.
 - Generalized Nano Server package support.
-- Both ResourceMSU and Nano Server packages can now be installed on Template VHDs and Virtual Machines.
+- Both ResourceMSU and Nano Server packages can now be installed on Template VHDs
+  and Virtual Machines.
 - Automatically add Microsoft-NanoServer-DSC-Package.cab to new Nano Server VMs.
-- Added BindingAdapterName and BindingAdapterMac attribute to switch element to allow control over bound adapter.
-- GetCertificatePsFileContent Changed so that PFX certificate imported into Root store for non Nano Servers.
-- Automatically set xNetworking version in DSC Networking config to that of the highest version available on the Lab Host.
+- Added BindingAdapterName and BindingAdapterMac attribute to switch element to
+  allow control over bound adapter.
+- GetCertificatePsFileContent Changed so that PFX certificate imported into Root
+  store for non Nano Servers.
+- Automatically set xNetworking version in DSC Networking config to that of the
+  highest version available on the Lab Host.
 
 ## 0.7.3.0
 
-- DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to contain name of ISCSI Server.
-- samples\Sample_WS2012R2_DomainClustering.xml: Added ServerName property to all Failover Cluster servers DSC properties.
+- DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Added ServerName property to
+  contain name of ISCSI Server.
+- samples\Sample_WS2012R2_DomainClustering.xml: Added ServerName property to all
+  Failover Cluster servers DSC properties.
 - docs\labbuilderconfig-schema.md: Converted to UTF-8 to eliminate issues with Git.
 - support\Convert-XSDToMD.ps1: Added code to convert transformed output to UTF-8.
 - Start-Lab: Improved readability if timeout detect code.
 - Stop-Lab: Improved readability if timeout detect code.
             Ensure all VMs are stopped in a Bootphase, even if timeout occurs.
-- StartDSCDebug.ps1: Added a WaitForDebugger parameter to StartDSCDebug.ps1 that will cause LCM to start with debugging mode enabled.
-- Lib\Type.ps1: File removed and content moved to header of LabBuilder.psm1 so that types were available outside the module context.
+- StartDSCDebug.ps1: Added a WaitForDebugger parameter to StartDSCDebug.ps1 that
+  will cause LCM to start with debugging mode enabled.
+- Lib\Type.ps1: File removed and content moved to header of LabBuilder.psm1 so
+  that types were available outside the module context.
 - Stop-Lab: Removed Boot Phase timeout because Stop-VM does not return until VM shutdown.
 - Added support for ISO resources to be specified in the Lab configuration.
 - Added support for DVD Drives in Lab VM configuration.
 - DSCLibrary\MEMBER_ADFS.DSC.ps1: Added DSC Library Configuration for ADFS.
-- samples\Sample_WS2012R2_MultiForest_ADFS.ps1: Added Sample Lab for creating multiple forests for ADFS testing.
-- DSCLibrary\MEMBER_REMOTEACCESS_WAP.DSC.ps1: Added DSC Library Configuration for Remote Access and Web Application Proxy.
+- samples\Sample_WS2012R2_MultiForest_ADFS.ps1: Added Sample Lab for creating
+  multiple forests for ADFS testing.
+- DSCLibrary\MEMBER_REMOTEACCESS_WAP.DSC.ps1: Added DSC Library Configuration for
+  Remote Access and Web Application Proxy.
 - DSCLibrary\MEMBER_ADFS.DSC.ps1: Install WID.
 - DSCLibrary\MEMBER_WEBSERVER.ps1: Created resource for IIS Web Servers.
 - samples\Sample_WS2012R2_MultiForest_ADFS.xml: Added Web Application Servers.
@@ -277,16 +358,21 @@
 
 ## 0.7.2.0
 
-- DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Changed to install most File Server features on cluster nodes.
-- DSCLibrary\MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1: Created resource for Failover Cluster DHCP Server nodes.
+- DSCLibrary\MEMBER_FAILOVERCLUSTER_FS.DSC.ps1: Changed to install most File
+  Server features on cluster nodes.
+- DSCLibrary\MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1: Created resource for Failover
+  Cluster DHCP Server nodes.
 - Readme.md: Additional Documentation added.
 
 ## 0.7.1.0
 
-- Get-LabDSCNetworkingConfig: Fix DSC error occuring when a blank DNS Server address or Default Gateway address is set on an Adapter.
-- InitializeVhd: Prevent unnecessary results of disk partitioning and volume creation to console.
+- Get-LabDSCNetworkingConfig: Fix DSC error occuring when a blank DNS Server
+  address or Default Gateway address is set on an Adapter.
+- InitializeVhd: Prevent unnecessary results of disk partitioning and volume
+  creation to console.
 - UpdateVMDataDisks: Fix to incorrectly reported Data VHD type change error.
-- DSCLibrary\MEMBER_BRANCHCACHE_HOST.DSC.ps1: Created resource for BranchCache Hosted Servers.
+- DSCLibrary\MEMBER_BRANCHCACHE_HOST.DSC.ps1: Created resource for BranchCache
+  Hosted Servers.
 - DSCLibrary\MEMBER_FILESERVER_*.DSC.ps1: Added BranchCache for File Servers feature.
 - Readme.md: Added 'Lab Installation Process in Detail' section.
 
@@ -294,22 +380,27 @@
 
 - Initialize-LabSwitch: External switch correctly sets Adapter Name.
 - IsAdmin: Function removed because was not useful.
-- dsclibrary\DC_FORESTDOMAIN.DSC: New DSC Library config for creating child domains in an existing forest.
+- dsclibrary\DC_FORESTDOMAIN.DSC: New DSC Library config for creating child
+  domains in an existing forest.
 - Samples\Sample_WS2012R2_MultiForest.xml: Added child domains.
 - Get-LabSwitch: Converted to output array of LabSwitch objects.
-- Initialize-LabSwitch: Converted to use LabSwitch objects.
-                        Fixed bug setting VLAN Id on External and Internal Switch Adapters.
+- Initialize-LabSwitch:
+  - Converted to use LabSwitch objects.
+  - Fixed bug setting VLAN Id on External and Internal Switch Adapters.
 - Remove-LabSwitch: Converted to use LabSwitch objects.
 - Tests\Test_Sample_*.ps1: Test-StartLabVM function fixed.
 - DSCLibrary\MEMBER_*.DSC.ps1: Updated parameter examples to include DCName parameter.
-- DSCLibrary\DC_*.DSC.ps1: Added DNS Zone and forwarder options (setting forwarder requires xDNSServer 1.6.0.0).
+- DSCLibrary\DC_*.DSC.ps1: Added DNS Zone and forwarder options (setting forwarder
+  requires xDNSServer 1.6.0.0).
 - DSCLibrary\MEMBER_DNS.DSC.ps1: Created resource for member DNS servers.
 - Get-LabVMTemplateVHD: Converted to output array of LabVMTemplateVHD objects.
-- Initialize-LabVMTemplateVHD: Converted to use LabVMTemplateVHD objects.
-                               Check added to ensure Drive Letter is assigned to mounted ISO.
+- Initialize-LabVMTemplateVHD:
+  - Converted to use LabVMTemplateVHD objects.
+  - Check added to ensure Drive Letter is assigned to mounted ISO.
 - Remove-LabVMTemplateVHD: Converted to use LabVMTemplateVHD objects.
 - Readme.md: Windows Management Framework 5.0 (WMF 5.0) section added.
-- DSCLibrary\DC_FORESTDOMAIN.DSC.ps1: Changed name to DC_FORESTCHILDDOMAIN.DSC.ps1 to better indicate purpose.
+- DSCLibrary\DC_FORESTDOMAIN.DSC.ps1: Changed name to DC_FORESTCHILDDOMAIN.DSC.ps1
+  to better indicate purpose.
 - Get-LabVMTemplate: Converted to output array of LabVMTemplate objects.
 - Initialize-LabVMTemplate: Converted to use LabVMTemplate objects.
 - Remove-LabVMTemplate: Converted to use LabVMTemplate objects.
@@ -319,12 +410,15 @@
 - Lib\dsc.ps1: All functions converted to use LabVM objects.
 - Lib\vm.ps1: All functions converted to use LabVM objects.
 - Lib\vhd.ps1: All functions converted to use LabVM objects.
-- InitializeVhd: Fix error when attempting to create a new VHD/VHDx with a formatted volume.
+- InitializeVhd: Fix error when attempting to create a new VHD/VHDx with a
+  formatted volume.
 
 ## 0.6.0.0
 
-- New-Lab: Function added for creating a new Lab configuration file and basic folder structure.
-- Get-Lab: Redundant checks for XML valid removed because convered by XSD schema validation.
+- New-Lab: Function added for creating a new Lab configuration file and basic
+  folder structure.
+- Get-Lab: Redundant checks for XML valid removed because convered by XSD schema
+  validation.
 - Added Lib\Type.ps1 containing customg LabBuilder Classes and Enumerations.
 - Added functions for converting XSD schema to MD.
 - Fix to Nano Server Package caching bug.
@@ -334,46 +428,65 @@
 - VM\SetupComplete attribute supports rooted paths.
 - DSC\ConfigFile Lab setting supports rooted paths.
 - VM\UseDifferencingBootDisk default changed to 'Y'.
-- Get-ModulesInDSCConfig: Returns Array of objects containing ModuleName and ModuleVersion.
-                         Now returns PSDesiredStateConfiguration module if listed -expected that calling function will ignore if required.
-                         Added function to set the Module versions in a DSC Config.
+- Get-ModulesInDSCConfig:
+  - Returns Array of objects containing ModuleName and ModuleVersion.
+  - Now returns PSDesiredStateConfiguration module if listed -expected that
+    calling function will ignore if required.
+  - Added function to set the Module versions in a DSC Config.
 - Update-LabDSC: Updated to set Module versions in DSC Config files.
 - DSC Library: Module Version numbers removed from all DSC Library Configrations.
 - Test Sample file code updated to remove switches when lab uninstalled.
 - Uninstall-Lab: Management Switch automatically removed when Lab uninstalled.
-- Configuration Schema: Added Resources\MSU element.
-                        Added Settings\Resource attribute.
-                        Removed VM\Install element support, superceeded by Packages attribute.
+- Configuration Schema:
+  - Added Resources\MSU element.
+  - Added Settings\Resource attribute.
+  - Removed VM\Install element support, superceeded by Packages attribute.
 - Get-LabResourceModule: Function added.
 - Initialize-LabResourceModule: Function added.
 - Get-LabResourceMSU: Function added.
 - Initialize-LabResourceMSU: Function added.
-- Install-Lab: Fix CheckEnvironment bug.
-               Added calls to Initialize-LabResourceModule and Initialize-LabResourceMSU.
-- DownloadResources: Utility function removed, superceeded by Initialize-LabResourceModule and Initialize-LabResourceMSU functions
+- Install-Lab:
+  - Fix CheckEnvironment bug.
+  - Added calls to Initialize-LabResourceModule and Initialize-LabResourceMSU.
+- DownloadResources:
+  - Utility function removed, superceeded by Initialize-LabResourceModule and
+    Initialize-LabResourceMSU functions.
 - Get-LabVM: Removed Install\MSU support.
-- InitializeBootVM: Removed Install\MSU support.
-                    Added support for installing Packages from Resources\MSU element.
-- Initialize-LabVMTemplateVHD: MSU Resources specified in Packages attribute are added to Template VHD when converted.
-- Initialize-LabVMTemplate: MSU Resources specified in Packages attribute are added to Template  when copied.
+- InitializeBootVM:
+  - Removed Install\MSU support.
+  - Added support for installing Packages from Resources\MSU element.
+- Initialize-LabVMTemplateVHD:
+  - MSU Resources specified in Packages attribute are added to Template VHD when
+    converted.
+- Initialize-LabVMTemplate:
+  - MSU Resources specified in Packages attribute are added to Template  when copied.
 
 ## 0.5.0.0
 
-- BREKAING: Renamed Config parameter to Lab parameter to indicate the object is actually an object that also stores Lab state information.
-- Remove-LabVM: Removed parameter 'RemoveVHDs'. Added parameter RemoveVMFolder which causes the VM folder and all contents to be deleted.
+- BREKAING: Renamed Config parameter to Lab parameter to indicate the object is
+  actually an object that also stores Lab state information.
+- Remove-LabVM: Removed parameter 'RemoveVHDs'. Added parameter RemoveVMFolder
+  which causes the VM folder and all contents to be deleted.
 - Uninstall-Lab: Renamed "Remove" parameters to be singular names rather than plural.
-- Uninstall-Lab: Added parameter 'RemoveLabFolder' which will cause the entire Lab folder to be deleted.
+- Uninstall-Lab: Added parameter 'RemoveLabFolder' which will cause the entire
+  Lab folder to be deleted.
 - Uninstall-Lab: Added ShouldProcess support to ask user to confirm actions.
 - Update-Lab: Added function which just calls Install-Lab.
-- Start-LabVM: Renamed function to Install-LabVM so that it is not confused with Start-VM.
-- *-LabSwitch: Added Name array parameter to allow filtering of switches to work with.
-- *-LabVMTemplateVHD: Added Name array parameter to allow filtering of VM Template VHDs to work with.
-- *-LabVMTemplate: Added Name array parameter to allow filtering of VM Templates to work with.
+- Start-LabVM: Renamed function to Install-LabVM so that it is not confused with
+  Start-VM.
+- *-LabSwitch: Added Name array parameter to allow filtering of switches to work
+  with.
+- *-LabVMTemplateVHD: Added Name array parameter to allow filtering of VM Template
+  VHDs to work with.
+- *-LabVMTemplate: Added Name array parameter to allow filtering of VM Templates
+  to work with.
 - *-LabVM: Added Name array parameter to allow filtering of VMs to work with.
 - Samples: Updated sample code with additional examples.
 - Help completed for all exported cmdlets.
-- Get-LabVM: XML now validated against labbuilderconfig-schema.xsd in Schemas folder when loaded -unless SkipXMLValidation switch is passed.
-- All sample and test configuration XML files validated against labbuilderconfig-schema.xsd in schemas folder when unit tests run.
+- Get-LabVM: XML now validated against labbuilderconfig-schema.xsd in Schemas
+  folder when loaded -unless SkipXMLValidation switch is passed.
+- All sample and test configuration XML files validated against
+  labbuilderconfig-schema.xsd in schemas folder when unit tests run.
 - All sample and test configuration XML files updated with namespace -> xmlns="labbuilderconfig".
 
 ## 0.4.2.0
@@ -384,8 +497,10 @@
 
 ## 0.4.1.0
 
-- VHDParentPath setting made optional. Defaults to "Virtual Machine Hard Disks" under config.
-- Initialize-LabConfiguration function will create labpath and vhdparentpath folders if not exist.
+- VHDParentPath setting made optional. Defaults to "Virtual Machine Hard Disks"
+  under config.
+- Initialize-LabConfiguration function will create labpath and vhdparentpath
+  folders if not exist.
 - Removed Test-LabConfiguration function and tests moved to Get-LabConfiguration.
 - Added Disconnect-LabVM function to disconnect from a connect Lab VM.
 - Fixed bug setting TrustedHosts when connecting to Lab VM.
@@ -403,7 +518,8 @@
 ## 0.4.0.0
 
 - Some secondary non-exported functions moved into separate support libraries.
-- Initialize-LabVMTemplate caches NanoServerPackages from VHD template folder to Lab folder.
+- Initialize-LabVMTemplate caches NanoServerPackages from VHD template folder to
+  Lab folder.
 - Fix exception connecting to VM when TrustedHosts is set to '*'.
 - Fix path Lab VM files are created.
 - Support for creating Certificates for Nano Servers on the host added.
@@ -414,8 +530,10 @@
 - Added support for configuring Nano Server packages for each VM.
 - Removed MAC Address minimum/maximum value settings from configuration.
 - Fix bug with Wait-LabInitVM failing to copy InitialSetupComplete.txt file.
-- Added VMRootPath and LabBuilderFilesPath properties Get-LabVM array containing path where VM and LabBuilder files should be stored respectively.
-- Added TemplateVHD in templates/template config node for specifying the template VHD.
+- Added VMRootPath and LabBuilderFilesPath properties Get-LabVM array containing
+  path where VM and LabBuilder files should be stored respectively.
+- Added TemplateVHD in templates/template config node for specifying the template
+  VHD.
 
 ## 0.3.2.0
 
@@ -427,7 +545,8 @@
 
 ## 0.3.1.0
 
-- Disable 'Access Denied' test when connecting to new VM because this error is reported by VM that is still booting up.
+- Disable 'Access Denied' test when connecting to new VM because this error is
+  reported by VM that is still booting up.
 - Correct Verbose message shown when Integration Services enabled.
 - Added Verbose message to indicate creation of VM Initialization files.
 - Correct Verbose message not appearing when mounting VM boot disk image file.
@@ -440,8 +559,10 @@
 - Updated AppVeyor.yml to push more artifacts.
 - Fix issue preventing timeout from triggering.
 - Improved handling of Remoting connection by moving into a new function Connect-LabVM
-- IP Address of VMs automatically added to WS-Man Trusted Hosts to enable HTTP remoting connection.
-- Prevent error if Panther folder doesn't exist in VHD image when creating a new VM.
+- IP Address of VMs automatically added to WS-Man Trusted Hosts to enable HTTP
+  remoting connection.
+- Prevent error if Panther folder doesn't exist in VHD image when creating a new
+  VM.
 - Add support for multiple data disks for each VM.
 - Add support for creating new data disks by cloning exising VHDs.
 - Support for Fixed, Differencing and Shared data disks.
@@ -459,8 +580,3 @@
 ## 0.1.0.0
 
 - Initial Release.
-
-
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@
   - Update to require xDhcpServer resource 2.0.0.0.
 - `dsclibrary\MEMBER_DHCP.DSC.ps1`:
   - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_NPS_DFSTEST.ps1`:
+  - Fix to use correct name of the DFSReplicationGroup resource.
 
 ## 1.0.2.58
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-- `DSCLibrary\MEMBER_SUBCA.DSC.ps1`:
+- `dsclibrary\MEMBER_SUBCA.DSC.ps1`:
   - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
   - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
     setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
-- `DSCLibrary\MEMBER_ROOTCA.DSC.ps1`:
+- `dsclibrary\MEMBER_ROOTCA.DSC.ps1`:
   - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
   - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
     it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
@@ -14,19 +14,42 @@
     setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
   - Changed CApolicy.inf RenewalKeyLength to 4096, CNGHashAlgorithm to SHA256 and
     LoadDefaultTemplates to 0 - fixes [Issue-324](https://github.com/PlagueHO/LabBuilder/issues/324).
-- `DSCLibrary\STANDALONE_ROOTCA.DSC.ps1`:
+- `dsclibrary\STANDALONE_ROOTCA.DSC.ps1`:
   - Correct SubCA resource name to wait for - fixes [Issue-321](https://github.com/PlagueHO/LabBuilder/issues/321).
   - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
     it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
   - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
     setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
-- `DSCLibrary\STANDALONE_ROOTCA_NOSUBCA.DSC.ps1`:
+- `dsclibrary\STANDALONE_ROOTCA_NOSUBCA.DSC.ps1`:
   - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
     it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
   - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
     setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
 - Added `.markdownlint.json` file.
 - Fix markdown rule violations in `CHANGELOG.MD`.
+- `dsclibrary\MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1`:
+  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\STANDALONE_DHCPDNS.DSC.DSC.ps1`:
+  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\STANDALONE_INTERNET.DSC.DSC.ps1`:
+  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCPDNS.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCPNPAS2016.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
+- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
+  - Update to require xDhcpServer resource 2.0.0.0.
 
 ## 1.0.2.58
 

--- a/src/dsclibrary/DC_FORESTCHILDDOMAIN.DSC.ps1
+++ b/src/dsclibrary/DC_FORESTCHILDDOMAIN.DSC.ps1
@@ -110,7 +110,7 @@ Configuration DC_FORESTCHILDDOMAIN
             }
         }
         $Count=0
-        Foreach ($ADZone in $Node.ADZones)
+        foreach ($ADZone in $Node.ADZones)
         {
             $Count++
             xDnsServerADZone "ADZone$Count"
@@ -123,7 +123,7 @@ Configuration DC_FORESTCHILDDOMAIN
             }
         }
         $Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones)
+        foreach ($PrimaryZone in $Node.PrimaryZones)
         {
             $Count++
             xDnsServerPrimaryZone "PrimaryZone$Count"

--- a/src/dsclibrary/DC_FORESTPRIMARY.DSC.ps1
+++ b/src/dsclibrary/DC_FORESTPRIMARY.DSC.ps1
@@ -136,7 +136,7 @@ Configuration DC_FORESTPRIMARY
             }
         }
         $Count=0
-        Foreach ($ADZone in $Node.ADZones)
+        foreach ($ADZone in $Node.ADZones)
         {
             $Count++
             xDnsServerADZone "ADZone$Count"
@@ -149,7 +149,7 @@ Configuration DC_FORESTPRIMARY
             }
         }
         $Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones)
+        foreach ($PrimaryZone in $Node.PrimaryZones)
         {
             $Count++
             xDnsServerPrimaryZone "PrimaryZone$Count"

--- a/src/dsclibrary/DC_SECONDARY.DSC.ps1
+++ b/src/dsclibrary/DC_SECONDARY.DSC.ps1
@@ -106,7 +106,7 @@ Configuration DC_SECONDARY
             }
         }
         [System.Int32]$Count=0
-        Foreach ($ADZone in $Node.ADZones) {
+        foreach ($ADZone in $Node.ADZones) {
             $Count++
             xDnsServerADZone "ADZone$Count"
             {
@@ -118,7 +118,7 @@ Configuration DC_SECONDARY
             }
         }
         [System.Int32]$Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones) {
+        foreach ($PrimaryZone in $Node.PrimaryZones) {
             $Count++
             xDnsServerPrimaryZone "PrimaryZone$Count"
             {

--- a/src/dsclibrary/MEMBER_DHCP.DSC.ps1
+++ b/src/dsclibrary/MEMBER_DHCP.DSC.ps1
@@ -57,7 +57,7 @@ Configuration MEMBER_DHCP
 {
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName ComputerManagementDsc
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -119,11 +119,12 @@ Configuration MEMBER_DHCP
             }
             DependsOn            = '[Computer]JoinDomain'
         }
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
                 ScopeId       = $Scope.Name
@@ -136,11 +137,12 @@ Configuration MEMBER_DHCP
                 AddressFamily = $Scope.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -150,11 +152,12 @@ Configuration MEMBER_DHCP
                 AddressFamily    = $Reservation.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId

--- a/src/dsclibrary/MEMBER_DHCPDNS.DSC.ps1
+++ b/src/dsclibrary/MEMBER_DHCPDNS.DSC.ps1
@@ -65,7 +65,7 @@ Configuration MEMBER_DHCPDNS
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName ComputerManagementDsc
     Import-DscResource -ModuleName xDNSServer
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -135,11 +135,11 @@ Configuration MEMBER_DHCPDNS
             DependsOn            = '[Computer]JoinDomain'
         }
 
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
                 ScopeId       = $Scope.Name
@@ -152,11 +152,12 @@ Configuration MEMBER_DHCPDNS
                 AddressFamily = $Scope.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -166,11 +167,12 @@ Configuration MEMBER_DHCPDNS
                 AddressFamily    = $Reservation.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId
@@ -192,11 +194,12 @@ Configuration MEMBER_DHCPDNS
                 DependsOn        = '[Computer]JoinDomain'
             }
         }
-        $Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones)
+
+        $count=0
+        foreach ($PrimaryZone in $Node.PrimaryZones)
         {
-            $Count++
-            xDnsServerPrimaryZone "PrimaryZone$Count"
+            $count++
+            xDnsServerPrimaryZone "PrimaryZone$count"
             {
                 Ensure        = 'Present'
                 Name          = $PrimaryZone.Name

--- a/src/dsclibrary/MEMBER_DHCPNPAS.DSC.ps1
+++ b/src/dsclibrary/MEMBER_DHCPNPAS.DSC.ps1
@@ -61,7 +61,7 @@ Configuration MEMBER_DHCPNPAS
 {
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName ComputerManagementDsc
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -130,11 +130,12 @@ Configuration MEMBER_DHCPNPAS
             }
             DependsOn            = '[Computer]JoinDomain'
         }
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
                 ScopeId       = $Scope.Name
@@ -147,11 +148,12 @@ Configuration MEMBER_DHCPNPAS
                 AddressFamily = $Scope.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -161,11 +163,12 @@ Configuration MEMBER_DHCPNPAS
                 AddressFamily    = $Reservation.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId

--- a/src/dsclibrary/MEMBER_DHCPNPAS2016.DSC.ps1
+++ b/src/dsclibrary/MEMBER_DHCPNPAS2016.DSC.ps1
@@ -61,7 +61,7 @@ Configuration MEMBER_DHCPNPAS2016
 {
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName ComputerManagementDsc
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -130,11 +130,12 @@ Configuration MEMBER_DHCPNPAS2016
             }
             DependsOn            = '[Computer]JoinDomain'
         }
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
                 ScopeId       = $Scope.Name
@@ -147,11 +148,12 @@ Configuration MEMBER_DHCPNPAS2016
                 AddressFamily = $Scope.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -161,11 +163,12 @@ Configuration MEMBER_DHCPNPAS2016
                 AddressFamily    = $Reservation.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId

--- a/src/dsclibrary/MEMBER_DNS.DSC.ps1
+++ b/src/dsclibrary/MEMBER_DNS.DSC.ps1
@@ -80,7 +80,7 @@ Configuration MEMBER_DNS
             }
         }
         $Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones)
+        foreach ($PrimaryZone in $Node.PrimaryZones)
         {
             $Count++
             xDnsServerPrimaryZone "PrimaryZone$Count"

--- a/src/dsclibrary/MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1
+++ b/src/dsclibrary/MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1
@@ -62,7 +62,7 @@ Configuration MEMBER_FAILOVERCLUSTER_FS
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName ComputerManagementDsc
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -176,13 +176,15 @@ Configuration MEMBER_FAILOVERCLUSTER_FS
             }
             DependsOn            = '[Computer]JoinDomain'
         }
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
+                ScopeId       = $Scope.Name
                 IPStartRange  = $Scope.Start
                 IPEndRange    = $Scope.End
                 Name          = $Scope.Name
@@ -192,11 +194,12 @@ Configuration MEMBER_FAILOVERCLUSTER_FS
                 AddressFamily = $Scope.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -206,11 +209,12 @@ Configuration MEMBER_FAILOVERCLUSTER_FS
                 AddressFamily    = $Reservation.AddressFamily
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId

--- a/src/dsclibrary/MEMBER_NPS_DFSTEST.DSC.ps1
+++ b/src/dsclibrary/MEMBER_NPS_DFSTEST.DSC.ps1
@@ -76,7 +76,7 @@ Configuration MEMBER_NPS_DFSTEST
             DependsOn = "[WaitForAll]DC"
         }
 
-        DFSRepGroup RGPublic
+        DFSReplicationGroup RGPublic
         {
             GroupName = 'Public'
             Description = 'Public files for use by all departments'

--- a/src/dsclibrary/MEMBER_ROOTCA.DSC.ps1
+++ b/src/dsclibrary/MEMBER_ROOTCA.DSC.ps1
@@ -5,15 +5,15 @@ DSC Template Configuration File For use by LabBuilder
 .Desription
     Builds an Enterprise Root CA.
 .Parameters:
-    DomainName = "LABBUILDER.COM"
-    DomainAdminPassword = "P@ssword!1"
+    DomainName = 'LABBUILDER.COM'
+    DomainAdminPassword = 'P@ssword!1'
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $true
     InstallRSATTools = $true
-    CACommonName = "LABBUILDER.COM Root CA"
-    CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
-    CRLPublicationURLs = "65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
-    CACertPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt"
+    CACommonName = 'LABBUILDER.COM Root CA'
+    CADistinguishedNameSuffix = 'DC=LABBUILDER,DC=COM'
+    CRLPublicationURLs = '65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl'
+    CACertPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt'
     CRLPeriodUnits = 52
     CRLPeriod = 'Weeks'
     CRLOverlapUnits = 12
@@ -36,7 +36,7 @@ Configuration MEMBER_ROOTCA
         # Assemble the Local Admin Credentials
         if ($Node.LocalAdminPassword)
         {
-            [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ("Administrator", (ConvertTo-SecureString $Node.LocalAdminPassword -AsPlainText -Force))
+            [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ('Administrator', (ConvertTo-SecureString $Node.LocalAdminPassword -AsPlainText -Force))
         }
         if ($Node.DomainAdminPassword)
         {
@@ -55,13 +55,13 @@ Configuration MEMBER_ROOTCA
         {
             Name      = 'ADCS-Web-Enrollment'
             Ensure    = 'Present'
-            DependsOn = "[WindowsFeature]ADCSCA"
+            DependsOn = '[WindowsFeature]ADCSCA'
         }
 
         WindowsFeature InstallWebMgmtService
         {
-            Ensure    = "Present"
-            Name      = "Web-Mgmt-Service"
+            Ensure    = 'Present'
+            Name      = 'Web-Mgmt-Service'
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
         }
 
@@ -69,9 +69,9 @@ Configuration MEMBER_ROOTCA
         {
             WindowsFeature RSAT-ManagementTools
             {
-                Ensure    = "Present"
-                Name      = "RSAT-AD-Tools"
-                DependsOn = "[WindowsFeature]ADCSCA"
+                Ensure    = 'Present'
+                Name      = 'RSAT-AD-Tools'
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
         }
 
@@ -82,7 +82,7 @@ Configuration MEMBER_ROOTCA
             {
                 Name      = 'ADCS-Online-Cert'
                 Ensure    = 'Present'
-                DependsOn = "[WindowsFeature]ADCSCA"
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
         }
 
@@ -93,14 +93,14 @@ Configuration MEMBER_ROOTCA
             {
                 Name      = 'ADCS-Enroll-Web-Svc'
                 Ensure    = 'Present'
-                DependsOn = "[WindowsFeature]ADCSCA"
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
 
             WindowsFeature EnrollmentWebPol
             {
                 Name      = 'ADCS-Enroll-Web-Pol'
                 Ensure    = 'Present'
-                DependsOn = "[WindowsFeature]ADCSCA"
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
         }
 
@@ -119,7 +119,7 @@ Configuration MEMBER_ROOTCA
             Name       = $Node.NodeName
             DomainName = $Node.DomainName
             Credential = $DomainAdminCredential
-            DependsOn  = "[WaitForAll]DC"
+            DependsOn  = '[WaitForAll]DC'
         }
 
         # Create the CAPolicy.inf file that sets basic parameters for certificate issuance for this CA.
@@ -127,13 +127,15 @@ Configuration MEMBER_ROOTCA
         {
             Ensure          = 'Present'
             DestinationPath = 'C:\Windows\CAPolicy.inf'
-            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n DiscreteSignatureAlgorithm=1`r`n HashAlgorithm=RSASHA256`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
+            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n AlternateSignatureAlgorithm=0`r`n HashAlgorithm=RSASHA256`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
             Type            = 'File'
             DependsOn       = '[Computer]JoinDomain'
         }
 
-        # Make a CertEnroll folder to put the Root CA certificate into.
-        # The CA Web Enrollment server would also create this but we need it now.
+        <#
+            Make a CertEnroll folder to put the Root CA certificate into.
+            The CA Web Enrollment server would also create this but we need it now.
+        #>
         File CertEnrollFolder
         {
             Ensure          = 'Present'
@@ -142,8 +144,10 @@ Configuration MEMBER_ROOTCA
             DependsOn       = '[File]CAPolicy'
         }
 
-        # Configure the Root CA which will create the Certificate REQ file that Root CA will use
-        # to issue a certificate for this Sub CA.
+        <#
+            Configure the Root CA which will create the Certificate REQ file that Root CA will use
+            to issue a certificate for this Sub CA.
+        #>
         ADCSCertificationAuthority ConfigCA
         {
             Ensure                    = 'Present'
@@ -163,13 +167,14 @@ Configuration MEMBER_ROOTCA
         ADCSWebEnrollment ConfigWebEnrollment {
             Ensure           = 'Present'
             IsSingleInstance = 'Yes'
-            CAConfig         = 'CertSrv'
             Credential       = $LocalAdminCredential
             DependsOn        = '[ADCSCertificationAuthority]ConfigCA'
         }
 
-        # Perform final configuration of the CA which will cause the CA service to startup
-        # Set the advanced CA properties
+        <#
+            Perform final configuration of the CA which will cause the CA service to startup
+            Set the advanced CA properties
+        #>
         Script ADCSAdvConfig
         {
             SetScript  = {
@@ -178,38 +183,47 @@ Configuration MEMBER_ROOTCA
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSConfigDN "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSDomainDN "$($Using:Node.CADistinguishedNameSuffix)"
                 }
+
                 if ($Using:Node.CRLPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPublicationURLs $($Using:Node.CRLPublicationURLs)
                 }
+
                 if ($Using:Node.CACertPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CACertPublicationURLs $($Using:Node.CACertPublicationURLs)
                 }
+
                 if ($Using:Node.CRLPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriodUnits $($Using:Node.CRLPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriod "$($Using:Node.CRLPeriod)"
                 }
+
                 if ($Using:Node.CRLOverlapUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapUnits $($Using:Node.CRLOverlapUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapPeriod "$($Using:Node.CRLOverlapPeriod)"
                 }
+
                 if ($Using:Node.ValidityPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriodUnits $($Using:Node.ValidityPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriod "$($Using:Node.ValidityPeriod)"
                 }
+
                 if ($Using:Node.AuditFilter)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\AuditFilter $($Using:Node.AuditFilter)
                 }
+
                 Restart-Service -Name CertSvc
-                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value "Certificate Service Restarted ..."
+                New-Item -Path 'c:\windows\setup\scripts\' -ItemType Directory -ErrorAction SilentlyContinue
+                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value 'Certificate Service Restarted ...'
             }
+
             GetScript  = {
-                Return @{
+                return @{
                     'DSConfigDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN');
                     'DSDomainDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN');
                     'CRLPublicationURLs'    = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs');
@@ -223,53 +237,66 @@ Configuration MEMBER_ROOTCA
                     'AuditFilter'           = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter')
                 }
             }
+
             TestScript = {
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN') -ne "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN') -ne "$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs') -ne $Using:Node.CRLPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CACertPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertPublicationURLs') -ne $Using:Node.CACertPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriodUnits') -ne $Using:Node.CRLPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriod') -ne $Using:Node.CRLPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapUnits') -ne $Using:Node.CRLOverlapUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapPeriod') -ne $Using:Node.CRLOverlapPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriodUnits') -ne $Using:Node.ValidityPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriod') -ne $Using:Node.ValidityPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.AuditFilter) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter') -ne $Using:Node.AuditFilter))
                 {
-                    Return $false
+                    return $false
                 }
-                Return $true
+
+                return $true
             }
+
             DependsOn  = '[ADCSWebEnrollment]ConfigWebEnrollment'
         }
 
@@ -286,23 +313,23 @@ Configuration MEMBER_ROOTCA
             # Enable Online Responder FireWall rules so we can remote manage Online Responder
             Firewall OnlineResponderFirewall1
             {
-                Name      = "Microsoft-Windows-OnlineRevocationServices-OcspSvc-DCOM-In"
-                Enabled   = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name      = 'Microsoft-Windows-OnlineRevocationServices-OcspSvc-DCOM-In'
+                Enabled   = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
 
             Firewall OnlineResponderirewall2
             {
-                Name      = "Microsoft-Windows-CertificateServices-OcspSvc-RPC-TCP-In"
-                Enabled   = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name      = 'Microsoft-Windows-CertificateServices-OcspSvc-RPC-TCP-In'
+                Enabled   = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
 
             Firewall OnlineResponderFirewall3
             {
-                Name      = "Microsoft-Windows-OnlineRevocationServices-OcspSvc-TCP-Out"
-                Enabled   = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name      = 'Microsoft-Windows-OnlineRevocationServices-OcspSvc-TCP-Out'
+                Enabled   = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
         }
     }

--- a/src/dsclibrary/MEMBER_SUBCA.DSC.ps1
+++ b/src/dsclibrary/MEMBER_SUBCA.DSC.ps1
@@ -5,17 +5,17 @@ DSC Template Configuration File For use by LabBuilder
 .Desription
     Builds a Enterprise Subordinate\Issuing CA.
 .Parameters:
-    DomainName = "LABBUILDER.COM"
-    DomainAdminPassword = "P@ssword!1"
+    DomainName = 'LABBUILDER.COM'
+    DomainAdminPassword = 'P@ssword!1'
     DCName = 'SA-DC1'
     PSDscAllowDomainUser = $true
     InstallRSATTools = $true
-    CACommonName = "LABBUILDER.COM Issuing CA"
-    CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
-    CRLPublicationURLs = "65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
-    CACertPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt"
-    RootCAName = "SS_ROOTCA"
-    RootCACommonName = "LABBUILDER.COM Root CA"
+    CACommonName = 'LABBUILDER.COM Issuing CA'
+    CADistinguishedNameSuffix = 'DC=LABBUILDER,DC=COM'
+    CRLPublicationURLs = '65:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n79:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n6:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl'
+    CACertPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt'
+    RootCAName = 'SS_ROOTCA'
+    RootCACommonName = 'LABBUILDER.COM Root CA'
 ###################################################################################################>
 
 Configuration MEMBER_SUBCA
@@ -45,13 +45,13 @@ Configuration MEMBER_SUBCA
         WindowsFeature WebEnrollmentCA {
             Name = 'ADCS-Web-Enrollment'
             Ensure = 'Present'
-            DependsOn = "[WindowsFeature]ADCSCA"
+            DependsOn = '[WindowsFeature]ADCSCA'
         }
 
         WindowsFeature InstallWebMgmtService
         {
-            Ensure = "Present"
-            Name = "Web-Mgmt-Service"
+            Ensure = 'Present'
+            Name = 'Web-Mgmt-Service'
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
         }
 
@@ -59,9 +59,9 @@ Configuration MEMBER_SUBCA
         {
             WindowsFeature RSAT-ManagementTools
             {
-                Ensure    = "Present"
-                Name      = "RSAT-AD-Tools"
-                DependsOn = "[WindowsFeature]ADCSCA"
+                Ensure    = 'Present'
+                Name      = 'RSAT-AD-Tools'
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
         }
 
@@ -70,7 +70,7 @@ Configuration MEMBER_SUBCA
             WindowsFeature OnlineResponderCA {
                 Name = 'ADCS-Online-Cert'
                 Ensure = 'Present'
-                DependsOn = "[WindowsFeature]ADCSCA"
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
         }
 
@@ -79,13 +79,13 @@ Configuration MEMBER_SUBCA
             WindowsFeature EnrollmentWebSvc {
                 Name = 'ADCS-Enroll-Web-Svc'
                 Ensure = 'Present'
-                DependsOn = "[WindowsFeature]ADCSCA"
+                DependsOn = '[WindowsFeature]ADCSCA'
             }
 
             WindowsFeature EnrollmentWebPol {
                 Name = 'ADCS-Enroll-Web-Pol'
                 Ensure = 'Present'
-                DependsOn = "[WindowsFeature]WebEnrollmentCA"
+                DependsOn = '[WindowsFeature]WebEnrollmentCA'
             }
         }
 
@@ -104,7 +104,7 @@ Configuration MEMBER_SUBCA
             Name          = $Node.NodeName
             DomainName    = $Node.DomainName
             Credential    = $DomainAdminCredential
-            DependsOn = "[WaitForAll]DC"
+            DependsOn = '[WaitForAll]DC'
         }
 
         # Create the CAPolicy.inf file that sets basic parameters for certificate issuance for this CA.
@@ -112,13 +112,15 @@ Configuration MEMBER_SUBCA
         {
             Ensure = 'Present'
             DestinationPath = 'C:\Windows\CAPolicy.inf'
-            Contents = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n RenewalKeyLength=2048`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=10`r`n LoadDefaultTemplates=1`r`n AlternateSignatureAlgorithm=1`r`n"
+            Contents = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=10`r`n AlternateSignatureAlgorithm=1`r`n CNGHashAlgorithm=SHA256`r`n LoadDefaultTemplates=0`r`n"
             Type = 'File'
             DependsOn = '[Computer]JoinDomain'
         }
 
-        # Make a CertEnroll folder to put the Root CA certificate into.
-        # The CA Web Enrollment server would also create this but we need it now.
+        <#
+            Make a CertEnroll folder to put the Root CA certificate into.
+            The CA Web Enrollment server would also create this but we need it now.
+        #>
         File CertEnrollFolder
         {
             Ensure = 'Present'
@@ -127,15 +129,17 @@ Configuration MEMBER_SUBCA
             DependsOn = '[File]CAPolicy'
         }
 
-        # Wait for the RootCA Web Enrollment to complete so we can grab the Root CA certificate
-        # file.
+        <#
+            Wait for the RootCA Web Enrollment to complete so we can grab the Root CA
+            certificate file.
+        #>
         WaitForAny RootCA
         {
             ResourceName = '[ADCSWebEnrollment]ConfigWebEnrollment'
             NodeName = $Node.RootCAName
             RetryIntervalSec = 30
             RetryCount = 30
-            DependsOn = "[File]CertEnrollFolder"
+            DependsOn = '[File]CertEnrollFolder'
         }
 
         # Download the Root CA certificate file.
@@ -169,22 +173,24 @@ Configuration MEMBER_SUBCA
                 & "$($ENV:SystemRoot)\system32\certutil.exe" -addstore -f root "C:\Windows\System32\CertSrv\CertEnroll\$($Node.RootCACommonName).crl"
             }
             GetScript = {
-                Return @{
+                return @{
                     Installed = ((Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object -FilterScript { ($_.Subject -Like "CN=$($Using:Node.RootCACommonName),*") -and ($_.Issuer -Like "CN=$($Using:Node.RootCACommonName),*") } ).Count -EQ 0)
                 }
             }
             TestScript = {
                 if ((Get-ChildItem -Path Cert:\LocalMachine\Root | Where-Object -FilterScript { ($_.Subject -Like "CN=$($Using:Node.RootCACommonName),*") -and ($_.Issuer -Like "CN=$($Using:Node.RootCACommonName),*") } ).Count -EQ 0) {
                     Write-Verbose -Message "Root CA Certificate Needs to be installed..."
-                    Return $false
+                    return $false
                 }
-                Return $true
+                return $true
             }
             DependsOn = '[xRemoteFile]DownloadRootCACRTFile'
         }
 
-        # Configure the Sub CA which will create the Certificate REQ file that Root CA will use
-        # to issue a certificate for this Sub CA.
+        <#
+            Configure the Sub CA which will create the Certificate REQ file that Root CA will use
+            to issue a certificate for this Sub CA.
+        #>
         ADCSCertificationAuthority ConfigCA
         {
             Ensure = 'Present'
@@ -205,7 +211,6 @@ Configuration MEMBER_SUBCA
         ADCSWebEnrollment ConfigWebEnrollment {
             Ensure = 'Present'
             IsSingleInstance = 'Yes'
-            CAConfig = 'CertSrv'
             Credential = $LocalAdminCredential
             DependsOn = '[ADCSCertificationAuthority]ConfigCA'
         }
@@ -217,17 +222,17 @@ Configuration MEMBER_SUBCA
                 Add-WebConfigurationProperty -PSPath IIS:\ -Filter //staticContent -Name "." -Value @{fileExtension='.req';mimeType='application/pkcs10'}
             }
             GetScript = {
-                Return @{
+                return @{
                     'MimeType' = ((Get-WebConfigurationProperty -Filter "//staticContent/mimeMap[@fileExtension='.req']" -PSPath IIS:\ -Name *).mimeType);
                 }
             }
             TestScript = {
                 if (-not (Get-WebConfigurationProperty -Filter "//staticContent/mimeMap[@fileExtension='.req']" -PSPath IIS:\ -Name *)) {
                     # Mime type is not set
-                    Return $false
+                    return $false
                 }
                 # Mime Type is already set
-                Return $true
+                return $true
             }
             DependsOn = '[ADCSWebEnrollment]ConfigWebEnrollment'
         }
@@ -239,7 +244,7 @@ Configuration MEMBER_SUBCA
             NodeName = $Node.RootCAName
             RetryIntervalSec = 30
             RetryCount = 30
-            DependsOn = "[Script]SetREQMimeType"
+            DependsOn = '[Script]SetREQMimeType'
         }
 
         # Download the Certificate for this SubCA but rename it so that it'll match the name expected by the CA
@@ -259,21 +264,23 @@ Configuration MEMBER_SUBCA
                 & "$($ENV:SystemRoot)\system32\certutil.exe" -installCert "C:\Windows\System32\CertSrv\CertEnroll\$($Using:Node.NodeName)_$($Using:Node.CACommonName).crt"
             }
             GetScript = {
-                Return @{
+                return @{
                 }
             }
             TestScript = {
                 if (-not (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertHash')) {
-                    Write-Verbose -Message "Sub CA Certificate needs to be registered with the Certification Authority..."
-                    Return $false
+                    Write-Verbose -Message 'Sub CA Certificate needs to be registered with the Certification Authority...'
+                    return $false
                 }
-                Return $true
+                return $true
             }
             DependsOn = '[xRemoteFile]DownloadSubCACERFile'
         }
 
-        # Perform final configuration of the CA which will cause the CA service to startup
-        # It should be able to start up once the SubCA certificate has been installed.
+        <#
+            Perform final configuration of the CA which will cause the CA service to startup
+            It should be able to start up once the SubCA certificate has been installed.
+        #>
         Script ADCSAdvConfig
         {
             SetScript = {
@@ -281,38 +288,49 @@ Configuration MEMBER_SUBCA
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSConfigDN "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSDomainDN "$($Using:Node.CADistinguishedNameSuffix)"
                 }
+
                 if ($Using:Node.CRLPublicationURLs) {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPublicationURLs $($Using:Node.CRLPublicationURLs)
                 }
+
                 if ($Using:Node.CACertPublicationURLs) {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CACertPublicationURLs $($Using:Node.CACertPublicationURLs)
                 }
+
                 Restart-Service -Name CertSvc
-                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value "Certificate Service Restarted ..."
+                New-Item -Path 'c:\windows\setup\scripts\' -ItemType Directory -ErrorAction SilentlyContinue
+                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value 'Certificate Service Restarted ...'
             }
+
             GetScript = {
-                Return @{
+                return @{
                     'DSConfigDN' = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN');
                     'DSDomainDN' = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN');
                     'CRLPublicationURLs'  = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs');
                     'CACertPublicationURLs'  = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertPublicationURLs')
                 }
             }
+
             TestScript = {
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN') -ne "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)")) {
-                    Return $false
+                    return $false
                 }
+
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN') -ne "$($Using:Node.CADistinguishedNameSuffix)")) {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs') -ne $Using:Node.CRLPublicationURLs)) {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CACertPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertPublicationURLs') -ne $Using:Node.CACertPublicationURLs)) {
-                    Return $false
+                    return $false
                 }
-                Return $true
+
+                return $true
             }
+
             DependsOn = '[Script]RegisterSubCA'
         }
 
@@ -328,23 +346,23 @@ Configuration MEMBER_SUBCA
             # Enable Online Responder FireWall rules so we can remote manage Online Responder
             Firewall OnlineResponderFirewall1
             {
-                Name = "Microsoft-Windows-OnlineRevocationServices-OcspSvc-DCOM-In"
-                Enabled = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name = 'Microsoft-Windows-OnlineRevocationServices-OcspSvc-DCOM-In'
+                Enabled = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
 
             Firewall OnlineResponderirewall2
             {
-                Name = "Microsoft-Windows-CertificateServices-OcspSvc-RPC-TCP-In"
-                Enabled = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name = 'Microsoft-Windows-CertificateServices-OcspSvc-RPC-TCP-In'
+                Enabled = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
 
             Firewall OnlineResponderFirewall3
             {
-                Name = "Microsoft-Windows-OnlineRevocationServices-OcspSvc-TCP-Out"
-                Enabled = "True"
-                DependsOn = "[ADCSOnlineResponder]ConfigOnlineResponder"
+                Name = 'Microsoft-Windows-OnlineRevocationServices-OcspSvc-TCP-Out'
+                Enabled = 'True'
+                DependsOn = '[ADCSOnlineResponder]ConfigOnlineResponder'
             }
         }
     }

--- a/src/dsclibrary/MEMBER_WEBSERVER.DSC.ps1
+++ b/src/dsclibrary/MEMBER_WEBSERVER.DSC.ps1
@@ -111,7 +111,7 @@ Configuration MEMBER_WEBSERVER
 
         # Create the Web App Pools
         [System.Int32]$Count=0
-        Foreach ($WebAppPool in $Node.WebAppPools) {
+        foreach ($WebAppPool in $Node.WebAppPools) {
             $Count++
             xWebAppPool "WebAppPool$Count"
             {
@@ -123,7 +123,7 @@ Configuration MEMBER_WEBSERVER
 
         # Create the Web Sites
         [System.Int32]$Count=0
-        Foreach ($WebSite in $Node.WebSites) {
+        foreach ($WebSite in $Node.WebSites) {
             $Count++
 
             # Create an empty folder or copy content from Source Path
@@ -161,14 +161,14 @@ Configuration MEMBER_WEBSERVER
         }
 
         # Create the Web Applications
-        [System.Int32]$Count=0
-        Foreach ($WebApplication in $Node.WebApplications) {
-            $Count++
+        $count=0
+        foreach ($WebApplication in $Node.WebApplications) {
+            $count++
 
             # Create an empty folder or copy content from Source Path
             if ($WebApplication.SourcePath)
             {
-                File "WebApplicationContent$Count"
+                File "WebApplicationContent$count"
                 {
                     Ensure          = "Present"
                     SourcePath      = $WebApplication.SourcePath
@@ -179,7 +179,7 @@ Configuration MEMBER_WEBSERVER
             }
             else
             {
-                File "WebApplicationContent$Count"
+                File "WebApplicationContent$count"
                 {
                     Ensure          = "Present"
                     Type            = "Directory"
@@ -187,26 +187,26 @@ Configuration MEMBER_WEBSERVER
                 }
             } # if
 
-            xWebApplication "WebApplication$Count"
+            xWebApplication "WebApplication$count"
             {
                 Ensure             = $WebApplication.Ensure
                 WebSite            = $WebApplication.WebSite
                 Name               = $WebApplication.Name
                 WebAppPool         = $WebApplication.WebAppPool
                 PhysicalPath       = $WebApplication.PhysicalPath
-                DependsOn          = "[File]WebApplicationContent$Count"
+                DependsOn          = "[File]WebApplicationContent$count"
             }
         }
 
         # Create the Web Virtual Directories
-        [System.Int32]$Count=0
-        Foreach ($WebVirtualDirectory in $Node.WebVirtualDirectories) {
-            $Count++
+        $count=0
+        foreach ($WebVirtualDirectory in $Node.WebVirtualDirectories) {
+            $count++
 
             # Create an empty folder or copy content from Source Path
             if ($WebVirtualDirectory.SourcePath)
             {
-                File "WebVirtualDirectoryContent$Count"
+                File "WebVirtualDirectoryContent$count"
                 {
                     Ensure          = "Present"
                     SourcePath      = $WebVirtualDirectory.SourcePath
@@ -217,7 +217,7 @@ Configuration MEMBER_WEBSERVER
             }
             else
             {
-                File "WebVirtualDirectoryContent$Count"
+                File "WebVirtualDirectoryContent$count"
                 {
                     Ensure          = "Present"
                     Type            = "Directory"
@@ -225,14 +225,14 @@ Configuration MEMBER_WEBSERVER
                 }
             } # if
 
-            xWebVirtualDirectory "WebVirtualDirectory$Count"
+            xWebVirtualDirectory "WebVirtualDirectory$count"
             {
                 Ensure             = $WebVirtualDirectory.Ensure
                 WebSite            = $WebVirtualDirectory.WebSite
                 WebApplication     = $WebVirtualDirectory.WebApplication
                 PhysicalPath       = $WebVirtualDirectory.PhysicalPath
                 Name               = $WebVirtualDirectory.Name
-                DependsOn          = "[File]WebVirtualDirectoryContent$Count"
+                DependsOn          = "[File]WebVirtualDirectoryContent$count"
             }
         }
     }

--- a/src/dsclibrary/STANDALONE_DHCPDNS.DSC.ps1
+++ b/src/dsclibrary/STANDALONE_DHCPDNS.DSC.ps1
@@ -65,7 +65,7 @@ Configuration STANDALONE_DHCPDNS
 {
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName xDNSServer
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
     Node $AllNodes.NodeName {
         # Assemble the Local Admin Credentials
@@ -86,15 +86,18 @@ Configuration STANDALONE_DHCPDNS
             Name   = "DNS"
         }
 
-        # Add the DHCP Scope, Reservation and Options from
-        # the node configuration
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+        <#
+            Add the DHCP Scope, Reservation and Options from
+            the node configuration
+        #>
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
+                ScopeId       = $Scope.Name
                 IPStartRange  = $Scope.Start
                 IPEndRange    = $Scope.End
                 Name          = $Scope.Name
@@ -105,11 +108,12 @@ Configuration STANDALONE_DHCPDNS
                 DependsOn     = '[WindowsFeature]DHCPInstall'
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -120,11 +124,12 @@ Configuration STANDALONE_DHCPDNS
                 DependsOn        = '[WindowsFeature]DHCPInstall'
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId
@@ -148,11 +153,11 @@ Configuration STANDALONE_DHCPDNS
             }
         }
 
-        $Count=0
-        Foreach ($ADZone in $Node.ADZones)
+        $count=0
+        foreach ($ADZone in $Node.ADZones)
         {
-            $Count++
-            xDnsServerADZone "ADZone$Count"
+            $count++
+            xDnsServerADZone "ADZone$count"
             {
                 Ensure           = 'Present'
                 Name             = $ADZone.Name
@@ -163,11 +168,11 @@ Configuration STANDALONE_DHCPDNS
             }
         }
 
-        $Count=0
-        Foreach ($PrimaryZone in $Node.PrimaryZones)
+        $count=0
+        foreach ($PrimaryZone in $Node.PrimaryZones)
         {
-            $Count++
-            xDnsServerSecondaryZone "PrimaryZone$Count"
+            $count++
+            xDnsServerSecondaryZone "PrimaryZone$count"
             {
                 Ensure        = 'Present'
                 Name          = $PrimaryZone.Name

--- a/src/dsclibrary/STANDALONE_INTERNET.DSC.ps1
+++ b/src/dsclibrary/STANDALONE_INTERNET.DSC.ps1
@@ -13,7 +13,7 @@ Configuration STANDALONE_INTERNET
 {
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
     Import-DscResource -ModuleName xDNSServer
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
     Import-DscResource -ModuleName xWebAdministration
 
     Node $AllNodes.NodeName {
@@ -51,21 +51,18 @@ Configuration STANDALONE_INTERNET
             DependsOn       = '[WindowsFeature]WebServerInstall'
         }
 
-        # Add the special DNS A records that Windows OS's use
-        # to identify if the internet is available.
-        # Can't be done yet because Resources are too limited.
-
-        # Manually create the DHCP Groups
-
-        # Add the DHCP Scope, Reservation and Options from
-        # the node configuration
-        $Count=0
-        Foreach ($Scope in $Node.Scopes)
+        <#
+            Add the DHCP Scope, Reservation and Options from
+            the node configuration
+        #>
+        $count=0
+        foreach ($Scope in $Node.Scopes)
         {
-            $Count++
-            xDhcpServerScope "Scope$Count"
+            $count++
+            xDhcpServerScope "Scope$count"
             {
                 Ensure        = 'Present'
+                ScopeId       = $Scope.Name
                 IPStartRange  = $Scope.Start
                 IPEndRange    = $Scope.End
                 Name          = $Scope.Name
@@ -76,11 +73,12 @@ Configuration STANDALONE_INTERNET
                 DependsOn     = '[WindowsFeature]DHCPInstall'
             }
         }
-        $Count=0
-        Foreach ($Reservation in $Node.Reservations)
+
+        $count=0
+        foreach ($Reservation in $Node.Reservations)
         {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
+            $count++
+            xDhcpServerReservation "Reservation$count"
             {
                 Ensure           = 'Present'
                 ScopeID          = $Reservation.ScopeId
@@ -91,11 +89,12 @@ Configuration STANDALONE_INTERNET
                 DependsOn        = '[WindowsFeature]DHCPInstall'
             }
         }
-        $Count=0
-        Foreach ($ScopeOption in $Node.ScopeOptions)
+
+        $count=0
+        foreach ($ScopeOption in $Node.ScopeOptions)
         {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
+            $count++
+            xDhcpServerOption "ScopeOption$count"
             {
                 Ensure             = 'Present'
                 ScopeID            = $ScopeOption.ScopeId

--- a/src/dsclibrary/STANDALONE_ROOTCA.DSC.ps1
+++ b/src/dsclibrary/STANDALONE_ROOTCA.DSC.ps1
@@ -5,10 +5,10 @@ DSC Template Configuration File For use by LabBuilder
 .Desription
     Builds a Standalone Root CA and creates Issuing CA certificates for Sub CAs.
 .Parameters:
-            CACommonName = "LABBUILDER.COM Root CA"
-            CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
-            CRLPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n10:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n2:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
-            CACertPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt"
+            CACommonName = 'LABBUILDER.COM Root CA'
+            CADistinguishedNameSuffix = 'DC=LABBUILDER,DC=COM'
+            CRLPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n10:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n2:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl'
+            CACertPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt'
             CRLPeriodUnits = 52
             CRLPeriod = 'Weeks'
             CRLOverlapUnits = 12
@@ -39,8 +39,10 @@ Configuration STANDALONE_ROOTCA
             Ensure = 'Present'
         }
 
-        # Install ADCS Web Enrollment - only required because it creates the CertEnroll virtual folder
-        # Which we use to pass certificates to the Issuing/Sub CAs
+        <#
+            Install ADCS Web Enrollment - only required because it creates the CertEnroll virtual folder
+            Which we use to pass certificates to the Issuing/Sub CAs
+        #>
         WindowsFeature ADCSWebEnrollment
         {
             Ensure    = 'Present'
@@ -50,8 +52,8 @@ Configuration STANDALONE_ROOTCA
 
         WindowsFeature InstallWebMgmtService
         {
-            Ensure    = "Present"
-            Name      = "Web-Mgmt-Service"
+            Ensure    = 'Present'
+            Name      = 'Web-Mgmt-Service'
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
         }
 
@@ -60,7 +62,7 @@ Configuration STANDALONE_ROOTCA
         {
             Ensure          = 'Present'
             DestinationPath = 'C:\Windows\CAPolicy.inf'
-            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n DiscreteSignatureAlgorithm=1`r`n HashAlgorithm=RSASHA256`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
+            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n AlternateSignatureAlgorithm=0`r`n HashAlgorithm=RSASHA256`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
             Type            = 'File'
             DependsOn       = '[WindowsFeature]ADCSCA'
         }
@@ -100,38 +102,47 @@ Configuration STANDALONE_ROOTCA
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSConfigDN "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSDomainDN "$($Using:Node.CADistinguishedNameSuffix)"
                 }
+
                 if ($Using:Node.CRLPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPublicationURLs $($Using:Node.CRLPublicationURLs)
                 }
+
                 if ($Using:Node.CACertPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CACertPublicationURLs $($Using:Node.CACertPublicationURLs)
                 }
+
                 if ($Using:Node.CRLPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriodUnits $($Using:Node.CRLPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriod "$($Using:Node.CRLPeriod)"
                 }
+
                 if ($Using:Node.CRLOverlapUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapUnits $($Using:Node.CRLOverlapUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapPeriod "$($Using:Node.CRLOverlapPeriod)"
                 }
+
                 if ($Using:Node.ValidityPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriodUnits $($Using:Node.ValidityPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriod "$($Using:Node.ValidityPeriod)"
                 }
+
                 if ($Using:Node.AuditFilter)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\AuditFilter $($Using:Node.AuditFilter)
                 }
+
                 Restart-Service -Name CertSvc
-                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value "Certificate Service Restarted ..."
+                New-Item -Path 'c:\windows\setup\scripts\' -ItemType Directory -ErrorAction SilentlyContinue
+                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value 'Certificate Service Restarted ...'
             }
+
             GetScript  = {
-                Return @{
+                return @{
                     'DSConfigDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN');
                     'DSDomainDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN');
                     'CRLPublicationURLs'    = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs');
@@ -145,53 +156,66 @@ Configuration STANDALONE_ROOTCA
                     'AuditFilter'           = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter')
                 }
             }
+
             TestScript = {
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN') -ne "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN') -ne "$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs') -ne $Using:Node.CRLPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CACertPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertPublicationURLs') -ne $Using:Node.CACertPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriodUnits') -ne $Using:Node.CRLPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriod') -ne $Using:Node.CRLPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapUnits') -ne $Using:Node.CRLOverlapUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapPeriod') -ne $Using:Node.CRLOverlapPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriodUnits') -ne $Using:Node.ValidityPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriod') -ne $Using:Node.ValidityPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.AuditFilter) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter') -ne $Using:Node.AuditFilter))
                 {
-                    Return $false
+                    return $false
                 }
-                Return $true
+
+                return $true
             }
+
             DependsOn  = '[ADCSWebEnrollment]ConfigWebEnrollment'
         }
 
@@ -224,43 +248,51 @@ Configuration STANDALONE_ROOTCA
                     Write-Verbose -Message "Submitting C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.req to $($Using:Node.CACommonName)"
                     [System.String]$RequestResult = & "$($ENV:SystemRoot)\System32\Certreq.exe" -Config ".\$($Using:Node.CACommonName)" -Submit "C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.req"
                     $Matches = [Regex]::Match($RequestResult, 'RequestId:\s([0-9]*)')
+
                     if ($Matches.Groups.Count -lt 2)
                     {
-                        Write-Verbose -Message "Error getting Request ID from SubCA certificate submission."
-                        Throw "Error getting Request ID from SubCA certificate submission."
+                        Write-Verbose -Message 'Error getting Request ID from SubCA certificate submission.'
+                        Throw 'Error getting Request ID from SubCA certificate submission.'
                     }
+
                     [System.Int32]$RequestId = $Matches.Groups[1].Value
                     Write-Verbose -Message "Issuing $RequestId in $($Using:Node.CACommonName)"
                     [System.String]$SubmitResult = & "$($ENV:SystemRoot)\System32\CertUtil.exe" -Resubmit $RequestId
+
                     if ($SubmitResult -notlike 'Certificate issued.*')
                     {
-                        Write-Verbose -Message "Unexpected result issuing SubCA request."
-                        Throw "Unexpected result issuing SubCA request."
+                        Write-Verbose -Message 'Unexpected result issuing SubCA request.'
+                        throw 'Unexpected result issuing SubCA request.'
                     }
+
                     Write-Verbose -Message "Retrieving C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.req from $($Using:Node.CACommonName)"
                     [System.String]$RetrieveResult = & "$($ENV:SystemRoot)\System32\Certreq.exe" -Config ".\$($Using:Node.CACommonName)" -Retrieve $RequestId "C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.crt"
                 }
+
                 GetScript  = {
-                    Return @{
+                    return @{
                         'Generated' = (Test-Path -Path "C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.crt");
                     }
                 }
+
                 TestScript = {
                     if (-not (Test-Path -Path "C:\Windows\System32\CertSrv\CertEnroll\$Using:SubCA.crt"))
                     {
                         # SubCA Cert is not yet created
-                        Return $false
+                        return $false
                     }
+
                     # SubCA Cert has been created
-                    Return $true
+                    return $true
                 }
+
                 DependsOn  = "[xRemoteFile]DownloadSubCA_$SubCA"
             }
 
             # Wait for SubCA to install the CA Certificate
             WaitForAny "WaitForComplete_$SubCA"
             {
-                ResourceName     = '[Script]InstallSubCACert'
+                ResourceName     = '[Script]RegisterSubCA'
                 NodeName         = $SubCA
                 RetryIntervalSec = 30
                 RetryCount       = 30
@@ -273,14 +305,17 @@ Configuration STANDALONE_ROOTCA
                 SetScript  = {
                     Stop-Computer
                 }
+
                 GetScript  = {
-                    Return @{
+                    return @{
                     }
                 }
+
                 TestScript = {
                     # SubCA Cert is not yet created
-                    Return $false
+                    return $false
                 }
+
                 DependsOn  = "[WaitForAny]WaitForComplete_$SubCA"
             }
         }

--- a/src/dsclibrary/STANDALONE_ROOTCA.DSC.ps1
+++ b/src/dsclibrary/STANDALONE_ROOTCA.DSC.ps1
@@ -220,7 +220,7 @@ Configuration STANDALONE_ROOTCA
         }
 
         # Generate Issuing certificates for any SubCAs
-        Foreach ($SubCA in $Node.SubCAs)
+        foreach ($SubCA in $Node.SubCAs)
         {
 
             # Wait for SubCA to generate REQ

--- a/src/dsclibrary/STANDALONE_ROOTCA_NOSUBCA.DSC.ps1
+++ b/src/dsclibrary/STANDALONE_ROOTCA_NOSUBCA.DSC.ps1
@@ -5,10 +5,10 @@ DSC Template Configuration File For use by LabBuilder
 .Desription
     Builds a Standalone Root CA with no Sub CAs.
 .Parameters:
-            CACommonName = "LABBUILDER.COM Root CA"
-            CADistinguishedNameSuffix = "DC=LABBUILDER,DC=COM"
-            CRLPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n10:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n2:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl"
-            CACertPublicationURLs = "1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt"
+            CACommonName = 'LABBUILDER.COM Root CA'
+            CADistinguishedNameSuffix = 'DC=LABBUILDER,DC=COM'
+            CRLPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%3%8%9.crl\n10:ldap:///CN=%7%8,CN=%2,CN=CDP,CN=Public Key Services,CN=Services,%6%10\n2:http://pki.labbuilder.com/CertEnroll/%3%8%9.crl'
+            CACertPublicationURLs = '1:C:\Windows\system32\CertSrv\CertEnroll\%1_%3%4.crt\n2:ldap:///CN=%7,CN=AIA,CN=Public Key Services,CN=Services,%6%11\n2:http://pki.labbuilder.com/CertEnroll/%1_%3%4.crt'
 ###################################################################################################>
 
 Configuration STANDALONE_ROOTCA_NOSUBCA
@@ -20,7 +20,7 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
         # Assemble the Local Admin Credentials
         if ($Node.LocalAdminPassword)
         {
-            [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ("Administrator", (ConvertTo-SecureString $Node.LocalAdminPassword -AsPlainText -Force))
+            [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ('Administrator', (ConvertTo-SecureString $Node.LocalAdminPassword -AsPlainText -Force))
         }
 
         # Install the ADCS Certificate Authority
@@ -30,8 +30,10 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
             Ensure = 'Present'
         }
 
-        # Install ADCS Web Enrollment - only required because it creates the CertEnroll virtual folder
-        # Which we use to pass certificates to the Issuing/Sub CAs
+        <#
+            Install ADCS Web Enrollment - only required because it creates the CertEnroll virtual folder
+            Which we use to pass certificates to the Issuing/Sub CAs
+        #>
         WindowsFeature ADCSWebEnrollment
         {
             Ensure    = 'Present'
@@ -41,8 +43,8 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
 
         WindowsFeature InstallWebMgmtService
         {
-            Ensure    = "Present"
-            Name      = "Web-Mgmt-Service"
+            Ensure    = 'Present'
+            Name      = 'Web-Mgmt-Service'
             DependsOn = '[WindowsFeature]ADCSWebEnrollment'
         }
 
@@ -51,7 +53,7 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
         {
             Ensure          = 'Present'
             DestinationPath = 'C:\Windows\CAPolicy.inf'
-            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n DiscreteSignatureAlgorithm=1`r`n HashAlgorithm=RSASHA256`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
+            Contents        = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n AlternateSignatureAlgorithm=0`r`n HashAlgorithm=RSASHA256`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
             Type            = 'File'
             DependsOn       = '[WindowsFeature]ADCSCA'
         }
@@ -91,38 +93,47 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSConfigDN "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"
                     & "$($ENV:SystemRoot)\system32\certutil.exe" -setreg CA\DSDomainDN "$($Using:Node.CADistinguishedNameSuffix)"
                 }
+
                 if ($Using:Node.CRLPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPublicationURLs $($Using:Node.CRLPublicationURLs)
                 }
+
                 if ($Using:Node.CACertPublicationURLs)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CACertPublicationURLs $($Using:Node.CACertPublicationURLs)
                 }
+
                 if ($Using:Node.CRLPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriodUnits $($Using:Node.CRLPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLPeriod "$($Using:Node.CRLPeriod)"
                 }
+
                 if ($Using:Node.CRLOverlapUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapUnits $($Using:Node.CRLOverlapUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\CRLOverlapPeriod "$($Using:Node.CRLOverlapPeriod)"
                 }
+
                 if ($Using:Node.ValidityPeriodUnits)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriodUnits $($Using:Node.ValidityPeriodUnits)
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\ValidityPeriod "$($Using:Node.ValidityPeriod)"
                 }
+
                 if ($Using:Node.AuditFilter)
                 {
                     & "$($ENV:SystemRoot)\System32\certutil.exe" -setreg CA\AuditFilter $($Using:Node.AuditFilter)
                 }
+
                 Restart-Service -Name CertSvc
-                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value "Certificate Service Restarted ..."
+                New-Item -Path 'c:\windows\setup\scripts\' -ItemType Directory -ErrorAction SilentlyContinue
+                Add-Content -Path 'c:\windows\setup\scripts\certutil.log' -Value 'Certificate Service Restarted ...'
             }
+
             GetScript  = {
-                Return @{
+                return @{
                     'DSConfigDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN');
                     'DSDomainDN'            = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN');
                     'CRLPublicationURLs'    = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs');
@@ -136,53 +147,66 @@ Configuration STANDALONE_ROOTCA_NOSUBCA
                     'AuditFilter'           = (Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter')
                 }
             }
+
             TestScript = {
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSConfigDN') -ne "CN=Configuration,$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('DSDomainDN') -ne "$($Using:Node.CADistinguishedNameSuffix)"))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPublicationURLs') -ne $Using:Node.CRLPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CACertPublicationURLs) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CACertPublicationURLs') -ne $Using:Node.CACertPublicationURLs))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriodUnits') -ne $Using:Node.CRLPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLPeriod') -ne $Using:Node.CRLPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapUnits') -ne $Using:Node.CRLOverlapUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.CRLOverlapPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('CRLOverlapPeriod') -ne $Using:Node.CRLOverlapPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriodUnits) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriodUnits') -ne $Using:Node.ValidityPeriodUnits))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.ValidityPeriod) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('ValidityPeriod') -ne $Using:Node.ValidityPeriod))
                 {
-                    Return $false
+                    return $false
                 }
+
                 if (($Using:Node.AuditFilter) -and ((Get-ChildItem 'HKLM:\System\CurrentControlSet\Services\CertSvc\Configuration').GetValue('AuditFilter') -ne $Using:Node.AuditFilter))
                 {
-                    Return $false
+                    return $false
                 }
-                Return $true
+
+                return $true
             }
+
             DependsOn  = '[ADCSWebEnrollment]ConfigWebEnrollment'
         }
     }

--- a/src/dsclibrary/modules/MyDSCResources/xCertAuthorityServer/xCertAuthorityServer.DSC.Schema.psm1
+++ b/src/dsclibrary/modules/MyDSCResources/xCertAuthorityServer/xCertAuthorityServer.DSC.Schema.psm1
@@ -88,7 +88,7 @@ Configuration MEMBER_ROOTCA
         {
             Ensure = 'Present'
             DestinationPath = 'C:\Windows\CAPolicy.inf'
-            Contents = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n DiscreteSignatureAlgorithm=1`r`n HashAlgorithm=RSASHA256`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
+            Contents = "[Version]`r`n Signature= `"$Windows NT$`"`r`n[Certsrv_Server]`r`n AlternateSignatureAlgorithm=0`r`n HashAlgorithm=RSASHA256`r`n RenewalKeyLength=4096`r`n RenewalValidityPeriod=Years`r`n RenewalValidityPeriodUnits=20`r`n CRLDeltaPeriod=Days`r`n CRLDeltaPeriodUnits=0`r`n[CRLDistributionPoint]`r`n[AuthorityInformationAccess]`r`n"
             Type = 'File'
             DependsOn = '[Computer]JoinDomain'
         }

--- a/src/dsclibrary/modules/MyDSCResources/xDHCPServer/xDHCPServer.DSC.Schema.psm1
+++ b/src/dsclibrary/modules/MyDSCResources/xDHCPServer/xDHCPServer.DSC.Schema.psm1
@@ -1,19 +1,19 @@
- Configuration DHCP
+Configuration DHCP
 {
     Param
     (
         # Domain Admin Password
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DomainAdminPassword,
 
         # Local Admin Password
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $LocalAdminPassword,
 
         # Domain Name
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $DomainName,
 
@@ -31,85 +31,89 @@
         [Parameter(AttributeValues)]
         [hashtable]
         $Reservations
-
-
     )
 
-
-
     Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
-    Import-DscResource -ModuleName xDHCPServer
+    Import-DscResource -ModuleName xDHCPServer -ModuleVersion 2.0.0.0
 
-        # Assemble the Local Admin Credentials
-        if ($LocalAdminPassword) {
-            [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ("Administrator", (ConvertTo-SecureString $LocalAdminPassword -AsPlainText -Force))
-        }
-        if ($DomainAdminPassword) {
-            [PSCredential]$DomainAdminCredential = New-Object System.Management.Automation.PSCredential ("$DomainName\Administrator", (ConvertTo-SecureString $DomainAdminPassword -AsPlainText -Force))
-        }
+    # Assemble the Local Admin Credentials
+    if ($LocalAdminPassword)
+    {
+        [PSCredential]$LocalAdminCredential = New-Object System.Management.Automation.PSCredential ("Administrator", (ConvertTo-SecureString $LocalAdminPassword -AsPlainText -Force))
+    }
+    if ($DomainAdminPassword)
+    {
+        [PSCredential]$DomainAdminCredential = New-Object System.Management.Automation.PSCredential ("$DomainName\Administrator", (ConvertTo-SecureString $DomainAdminPassword -AsPlainText -Force))
+    }
 
-        WindowsFeature DHCPInstall
+    WindowsFeature DHCPInstall
+    {
+        Ensure = "Present"
+        Name   = "DHCP"
+    }
+
+    Script DHCPAuthorize
+    {
+        PSDSCRunAsCredential = $DomainAdminCredential
+        SetScript            = {
+            Add-DHCPServerInDC
+        }
+        GetScript            = {
+            Return @{
+                'Authorized' = (@(Get-DHCPServerInDC | Where-Object { $_.IPAddress -In (Get-NetIPAddress).IPAddress }).Count -gt 0);
+            }
+        }
+        TestScript           = {
+            Return (-not (@(Get-DHCPServerInDC | Where-Object { $_.IPAddress -In (Get-NetIPAddress).IPAddress }).Count -eq 0))
+        }
+        DependsOn            = '[WindowsFeature]DHCPInstall'
+    }
+
+    $count = 0
+    foreach ($Scope in $Scopes)
+    {
+        $count++
+        xDhcpServerScope "Scope$count"
         {
-            Ensure = "Present"
-            Name = "DHCP"
+            Ensure        = 'Present'
+            ScopeId       = $Scope.Name
+            IPStartRange  = $Scope.Start
+            IPEndRange    = $Scope.End
+            Name          = $Scope.Name
+            SubnetMask    = $Scope.SubnetMask
+            State         = 'Active'
+            LeaseDuration = '00:08:00'
+            AddressFamily = $Scope.AddressFamily
         }
+    }
 
-
-        Script DHCPAuthorize
+    $count = 0
+    foreach ($Reservation in $Reservations)
+    {
+        $count++
+        xDhcpServerReservation "Reservation$count"
         {
-            PSDSCRunAsCredential = $DomainAdminCredential
-            SetScript = {
-                Add-DHCPServerInDC
-            }
-            GetScript = {
-                Return @{
-                    'Authorized' = (@(Get-DHCPServerInDC | Where-Object { $_.IPAddress -In (Get-NetIPAddress).IPAddress }).Count -gt 0);
-                }
-            }
-            TestScript = {
-                Return (-not (@(Get-DHCPServerInDC | Where-Object { $_.IPAddress -In (Get-NetIPAddress).IPAddress }).Count -eq 0))
-            }
-            DependsOn = '[WindowsFeature]DHCPInstall'
+            Ensure           = 'Present'
+            ScopeID          = $Reservation.ScopeId
+            ClientMACAddress = $Reservation.ClientMACAddress
+            IPAddress        = $Reservation.IPAddress
+            Name             = $Reservation.Name
+            AddressFamily    = $Reservation.AddressFamily
         }
-        [System.Int32]$Count=0
-        Foreach ($Scope in $Scopes) {
-            $Count++
-            xDhcpServerScope "Scope$Count"
-            {
-                Ensure = 'Present'
-                IPStartRange = $Scope.Start
-                IPEndRange = $Scope.End
-                Name = $Scope.Name
-                SubnetMask = $Scope.SubnetMask
-                State = 'Active'
-                LeaseDuration = '00:08:00'
-                AddressFamily = $Scope.AddressFamily
-            }
+    }
+
+    $count = 0
+    foreach ($ScopeOption in $ScopeOptions)
+    {
+        $count++
+        xDhcpServerOption "ScopeOption$count"
+        {
+            Ensure             = 'Present'
+            ScopeID            = $ScopeOption.ScopeId
+            DnsDomain          = $DomainName
+            DnsServerIPAddress = $ScopeOption.DNServerIPAddress
+            Router             = $ScopeOption.Router
+            AddressFamily      = $ScopeOption.AddressFamily
         }
-        [System.Int32]$Count=0
-        Foreach ($Reservation in $Reservations) {
-            $Count++
-            xDhcpServerReservation "Reservation$Count"
-            {
-                Ensure = 'Present'
-                ScopeID = $Reservation.ScopeId
-                ClientMACAddress = $Reservation.ClientMACAddress
-                IPAddress = $Reservation.IPAddress
-                Name = $Reservation.Name
-                AddressFamily = $Reservation.AddressFamily
-            }
-        }
-        [System.Int32]$Count=0
-        Foreach ($ScopeOption in $ScopeOptions) {
-            $Count++
-            xDhcpServerOption "ScopeOption$Count"
-            {
-                Ensure = 'Present'
-                ScopeID = $ScopeOption.ScopeId
-                DnsDomain = $DomainName
-                DnsServerIPAddress = $ScopeOption.DNServerIPAddress
-                Router = $ScopeOption.Router
-                AddressFamily = $ScopeOption.AddressFamily
-            }
-        }
+    }
 }

--- a/src/lib/private/Set-LabDSC.ps1
+++ b/src/lib/private/Set-LabDSC.ps1
@@ -47,8 +47,10 @@ function Set-LabDSC
     # Get Path to LabBuilder files
     $vmLabBuilderFiles = $VM.LabBuilderFilesPath
 
-    # Relabel the Network Adapters so that they match what the DSC Networking config will use
-    # This is because unfortunately the Hyper-V Device Naming feature doesn't work.
+    <#
+        Relabel the Network Adapters so that they match what the DSC Networking config will use
+        This is because unfortunately the Hyper-V Device Naming feature doesn't work.
+    #>
     $managementSwitchName = Get-LabManagementSwitchName -Lab $Lab
     $adapters = [System.String[]] ($VM.Adapters).Name
     $adapters += @($managementSwitchName)
@@ -89,9 +91,11 @@ Get-NetAdapter ``
 "@
     } # Foreach
 
-    # Enable DSC logging (as long as it hasn't been already)
-    # Nano Server doesn't have the Microsoft-Windows-Dsc/Analytic channels so
-    # Logging can't be enabled.
+    <#
+        Enable DSC logging (as long as it hasn't been already)
+        Nano Server doesn't have the Microsoft-Windows-Dsc/Analytic channels so
+        Logging can't be enabled.
+    #>
     if ($VM.OSType -ne [LabOSType]::Nano)
     {
         $logging = ($VM.DSC.Logging).ToString()


### PR DESCRIPTION
- `dsclibrary\MEMBER_SUBCA.DSC.ps1`:
  - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
- `dsclibrary\MEMBER_ROOTCA.DSC.ps1`:
  - CAServer parameter removed from ADCSWebEnrollment - fixes [Issue-320](https://github.com/PlagueHO/LabBuilder/issues/320).
  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
  - Changed CApolicy.inf RenewalKeyLength to 4096, CNGHashAlgorithm to SHA256 and
    LoadDefaultTemplates to 0 - fixes [Issue-324](https://github.com/PlagueHO/LabBuilder/issues/324).
- `dsclibrary\STANDALONE_ROOTCA.DSC.ps1`:
  - Correct SubCA resource name to wait for - fixes [Issue-321](https://github.com/PlagueHO/LabBuilder/issues/321).
  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
- `dsclibrary\STANDALONE_ROOTCA_NOSUBCA.DSC.ps1`:
  - Change `DiscreteSignatureAlgorithm` to `AlternateSignatureAlgorithm` and set
    it to 0 - fixes [Issue-322](https://github.com/PlagueHO/LabBuilder/issues/322).
  - Fix error occuring when `c:\windows\setup\scripts\` folder does not exist when
    setting the advanced CA configuration settings - fixes [Issue-325](https://github.com/PlagueHO/LabBuilder/issues/325).
- Added `.markdownlint.json` file.
- Fix markdown rule violations in `CHANGELOG.MD`.
- `dsclibrary\MEMBER_FAILOVERCLUSTER_DHCP.DSC.ps1`:
  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\STANDALONE_DHCPDNS.DSC.DSC.ps1`:
  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\STANDALONE_INTERNET.DSC.DSC.ps1`:
  - Fix DHCP scope to work with newer version of xDhcpServerScope DSC resource.
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCPDNS.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCPNPAS2016.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.
- `dsclibrary\MEMBER_DHCP.DSC.ps1`:
  - Update to require xDhcpServer resource 2.0.0.0.

- Fixes #320 
- Fixes #321 
- Fixes #322 
- Fixes #324 
- Fixes #325

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/326)
<!-- Reviewable:end -->
