### PR TITLE
Change dsclibrarypath setting to default to Module Folder when missing - Fixes #335

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Enable RODC creation because it is supported by ActiveDirectoryDsc.
 - `dsclibrary\DC_FORESTPRIMARY.DSC.ps1`:
   - Enabled customizing of Domain NetBios name.
+- `Get-LabVm.ps1`:
+  - Clean up code style.
 
 ## 1.0.4.83
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@
   - Enabled customizing of Domain NetBios name.
 - `Get-LabVm.ps1`:
   - Clean up code style.
+- `Enable-LabWSMan.ps1`:
+  - Improved function so that if WinRM Service is stopped it will be started.
+- `Get-Lab.ps1`:
+  - Clean up code style.
+  - Fix bug reading `configpath` from `settings` node.
+  - Changed to use `ConvertTo-LabAbsolutePath.ps1` to simplify code.
+  - Changed to automatically use the `DSCLibrary` folder that comes as part of
+    the LabBuilder module if the `dsclibrarypath` setting is not specified
+    in the lab configuration - fixes [Issue-335](https://github.com/PlagueHO/LabBuilder/issues/335).
+- `ConvertTo-LabAbsolutePath.ps1`:
+  - Added function to create an absolute path from a relative lab path.
+- Removed `dsclibrarypath` setting from all samples as it is no longer required.
+- `Get-LabResourceISO.ps1`:
+  - Clean up code style.
 
 ## 1.0.4.83
 

--- a/docs/about_LabBuilderSchema.md
+++ b/docs/about_LabBuilderSchema.md
@@ -92,7 +92,7 @@ The Parent VHD files are used as Parent VHD's to any Lab VM boot disks or cloned
 
 This optional attribute contains the path to the folder that will contain the DSC Library files used by the Virtual Machines in this Lab.
 If this folder is not rooted, it will be assumed to be a subfolder of the 'labpath'.
-If this setting is not set it will default to 'dsclibrary' and will therefore be a subfolder of the 'labpath'.
+If this setting is not set it will default to the 'dsclibrary' folder within this module and will not be a subfolder of the 'labpath'.
 Usually the content of this folder will either be provided with the Lab or created by copying the DSCLibrary folder provided with the LabBuilder module.
 
 Each Virtual Machine that is set to be configured by DSC requires a DSC configuration file that must be found in this folder.

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -62,6 +62,7 @@ Task UnitTest -Depends Init, PrepareTest {
 
     # Execute tests
     $testScriptsPath = Join-Path -Path $ProjectRoot -ChildPath 'test\unit'
+
     if (-not (Test-Path -Path $testScriptsPath))
     {
         'Skipping unit tests because none exist'
@@ -96,6 +97,7 @@ Task UnitTest -Depends Init, PrepareTest {
                 -RepoRoot $ProjectRoot
 
             'Uploading CodeCoverage to CodeCov.io'
+
             try
             {
                 Invoke-UploadCoveCoveIoReport -Path $jsonPath
@@ -145,6 +147,7 @@ Task IntegrationTest -Depends Init, PrepareTest {
 
     # Execute tests
     $testScriptsPath = Join-Path -Path $ProjectRoot -ChildPath 'test\integration'
+
     if (-not (Test-Path -Path $testScriptsPath))
     {
         'Skipping integration tests because none exist'

--- a/src/LabBuilder.psm1
+++ b/src/LabBuilder.psm1
@@ -4,21 +4,23 @@
 #Requires -version 5.1
 #Requires -RunAsAdministrator
 
-$moduleRoot = Split-Path `
+$script:LabBuidlerModuleRoot = Split-Path `
     -Path $MyInvocation.MyCommand.Path `
     -Parent
 
 #region LocalizedData
-$Culture = 'en-us'
-if (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath $PSUICulture))
+$culture = 'en-us'
+
+if (Test-Path -Path (Join-Path -Path $script:LabBuidlerModuleRoot -ChildPath $PSUICulture))
 {
-    $Culture = $PSUICulture
+    $culture = $PSUICulture
 }
+
 Import-LocalizedData `
     -BindingVariable LocalizedData `
     -Filename 'LabBuilder_LocalizedData.psd1' `
-    -BaseDirectory $moduleRoot `
-    -UICulture $Culture
+    -BaseDirectory $script:LabBuidlerModuleRoot `
+    -UICulture $culture
 #endregion
 
 #region Types
@@ -533,11 +535,11 @@ class LabDSCModule:System.ICloneable {
 #region ImportFunctions
 # Dot source any functions in the libs folder
 $libFiles = Get-ChildItem `
-    -Path (Join-Path -Path $moduleRoot -ChildPath 'lib') `
+    -Path (Join-Path -Path $script:LabBuidlerModuleRoot -ChildPath 'lib') `
     -Include '*.ps1' `
     -Recurse
 
-Foreach ($libFile in $libFiles)
+foreach ($libFile in $libFiles)
 {
     Write-Verbose -Message $($LocalizedData.ImportingLibFileMessage -f $libFile.Fullname)
     . $libFile.Fullname

--- a/src/en-US/LabBuilder_LocalizedData.psd1
+++ b/src/en-US/LabBuilder_LocalizedData.psd1
@@ -110,8 +110,6 @@ ConvertFrom-StringData -StringData @'
     PackageSourceNotRegisteredError = The required package source '{0}' is not registered.
     ODJCopyError = Error copying Offline Domain Join file '{1}' to VM '{0}'.
     VMNotRunningHeartbeatError = Virtual Machine '{0}' is not running, so waiting for heartbeat failed.
-    LabBuilderModuleNotLoadedError = The path to the LabBuilder module failed to be detected because the module is not loaded.
-    LabBuilderModulePathNullError = The path to the LabBuilder module failed to be detected because the module path is null.
 
     ImportingLibFileMessage = Importing function library '{0}'.
     EnablingWSManMessage = Enabling WS-Man for communication with Lab Guests.

--- a/src/en-US/LabBuilder_LocalizedData.psd1
+++ b/src/en-US/LabBuilder_LocalizedData.psd1
@@ -110,6 +110,8 @@ ConvertFrom-StringData -StringData @'
     PackageSourceNotRegisteredError = The required package source '{0}' is not registered.
     ODJCopyError = Error copying Offline Domain Join file '{1}' to VM '{0}'.
     VMNotRunningHeartbeatError = Virtual Machine '{0}' is not running, so waiting for heartbeat failed.
+    LabBuilderModuleNotLoadedError = The path to the LabBuilder module failed to be detected because the module is not loaded.
+    LabBuilderModulePathNullError = The path to the LabBuilder module failed to be detected because the module path is null.
 
     ImportingLibFileMessage = Importing function library '{0}'.
     EnablingWSManMessage = Enabling WS-Man for communication with Lab Guests.

--- a/src/en-US/LabBuilder_LocalizedData.psd1
+++ b/src/en-US/LabBuilder_LocalizedData.psd1
@@ -104,6 +104,7 @@ ConvertFrom-StringData -StringData @'
     BindingAdapterUsedError = Error binding physical network adapter '{1}' to External Switch '{0}' because it is already bound to another External Switch.
     IPAddressError = The IP Address '{0}' is invalid.
     WSManNotEnabledError = WS-Man is not enabled.
+    WinRMServiceFailedToStartError = The WinRM service failed to start.
     PackageProviderNotInstalledError = The required package provider '{0}' is not installed.
     PackageSourceNotTrustedError = The required package source '{0}' is not trusted.
     PackageSourceNotRegisteredError = The required package source '{0}' is not registered.

--- a/src/lib/private/ConvertTo-LabAbsolutePath.ps1
+++ b/src/lib/private/ConvertTo-LabAbsolutePath.ps1
@@ -1,0 +1,37 @@
+<#
+    .SYNOPSIS
+        Convert a path to be an absolute by adding it to the base path.
+        If the path is already absolute then it is just returned as is.
+
+    .PARAMETER Path
+        The path to convert to an absolute path.
+
+    .PARAMETER BasePath
+        The full path to the lab.
+
+    .OUTPUTS
+        The path converted to an absolute path.
+#>
+function ConvertTo-LabAbsolutePath
+{
+    [CmdLetBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $BasePath
+    )
+
+    if (-not [System.IO.Path]::IsPathRooted($Path))
+    {
+        $Path = Join-Path `
+            -Path $BasePath `
+            -ChildPath $Path
+    } # if
+
+    return $Path
+}

--- a/src/lib/private/Copy-LabOdjFile.ps1
+++ b/src/lib/private/Copy-LabOdjFile.ps1
@@ -31,7 +31,8 @@
 function Copy-LabOdjFile
 {
     [CmdLetBinding()]
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         $Lab,
 
@@ -93,10 +94,10 @@ function Copy-LabOdjFile
             }
 
             # Connection has been made OK, upload the ODJ files
-            While ((-not $odjCopyComplete) `
+            while ((-not $odjCopyComplete) `
                 -and (((Get-Date) - $startTime).TotalSeconds) -lt $TimeOut)
             {
-                Try
+                try
                 {
                     Write-LabMessage -Message $($LocalizedData.CopyingFilesToVMMessage `
                         -f $VM.Name,'ODJ')
@@ -109,7 +110,7 @@ function Copy-LabOdjFile
                         -Verbose
                     $odjCopyComplete = $true
                 }
-                Catch
+                catch
                 {
                     Write-LabMessage -Message $($LocalizedData.CopyingFilesToVMFailedMessage `
                         -f $VM.Name,'ODJ',$Script:RetryConnectSeconds)
@@ -138,11 +139,11 @@ function Copy-LabOdjFile
         } # if
 
 
-            # Disconnect from the VM
-            Disconnect-LabVM `
-                -VM $VM `
-                -ErrorAction Continue
+        # Disconnect from the VM
+        Disconnect-LabVM `
+            -VM $VM `
+            -ErrorAction Continue
 
-            $complete = $true
+        $complete = $true
     } # while
 }

--- a/src/lib/private/Enable-LabWSMan.ps1
+++ b/src/lib/private/Enable-LabWSMan.ps1
@@ -50,4 +50,22 @@ function Enable-LabWSMan
             New-LabException @exceptionParameters
         } # if
     } # if
+
+    # Make sure the WinRM service is running
+    if ((Get-Service -Name WinRM).Status -ne 'Running')
+    {
+        try
+        {
+            Start-Service -Name WinRm -ErrorAction Stop
+        }
+        catch
+        {
+            $exceptionParameters = @{
+                errorId       = 'WinRMServiceFailedToStartError'
+                errorCategory = 'InvalidArgument'
+                errorMessage  = $($LocalizedData.WinRMServiceFailedToStartError)
+            }
+            New-LabException @exceptionParameters
+        }
+    }
 }

--- a/src/lib/private/Get-LabBuilderModulePath.ps1
+++ b/src/lib/private/Get-LabBuilderModulePath.ps1
@@ -18,7 +18,7 @@ function Get-LabBuilderModulePath
         $exceptionParameters = @{
             errorId       = 'LabBuilderModuleNotLoadedError'
             errorCategory = 'InvalidArgument'
-            errorMessage  = $($LocalizedData.LabBuilderModulePathDetectionError)
+            errorMessage  = $($LocalizedData.LabBuilderModuleNotLoadedError)
         }
         New-LabException @exceptionParameters
     }

--- a/src/lib/private/Get-LabBuilderModulePath.ps1
+++ b/src/lib/private/Get-LabBuilderModulePath.ps1
@@ -1,0 +1,15 @@
+<#
+    .SYNOPSIS
+        Returns the path of the currently loaded LabBuilder module.
+
+    .OUTPUTS
+        The path to the currently loaded LabBuilder module.
+#>
+function Get-LabBuilderModulePath
+{
+    [CmdLetBinding()]
+    [OutputType([System.String])]
+    param ()
+
+    return Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent
+}

--- a/src/lib/private/Get-LabBuilderModulePath.ps1
+++ b/src/lib/private/Get-LabBuilderModulePath.ps1
@@ -11,5 +11,27 @@ function Get-LabBuilderModulePath
     [OutputType([System.String])]
     param ()
 
-    return Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent
+    $module = Get-Module -Name LabBuilder
+
+    if (-not $module)
+    {
+        $exceptionParameters = @{
+            errorId       = 'LabBuilderModuleNotLoadedError'
+            errorCategory = 'InvalidArgument'
+            errorMessage  = $($LocalizedData.LabBuilderModulePathDetectionError)
+        }
+        New-LabException @exceptionParameters
+    }
+
+    if ([System.String]::IsNullOrEmpty($module.Path))
+    {
+        $exceptionParameters = @{
+            errorId       = 'LabBuilderModulePathNullError'
+            errorCategory = 'InvalidArgument'
+            errorMessage  = $($LocalizedData.LabBuilderModulePathNullError)
+        }
+        New-LabException @exceptionParameters
+    }
+
+    return Split-Path -Path $module.Path -Parent
 }

--- a/src/lib/private/Get-LabBuilderModulePath.ps1
+++ b/src/lib/private/Get-LabBuilderModulePath.ps1
@@ -11,27 +11,5 @@ function Get-LabBuilderModulePath
     [OutputType([System.String])]
     param ()
 
-    $module = Get-Module -Name LabBuilder
-
-    if (-not $module)
-    {
-        $exceptionParameters = @{
-            errorId       = 'LabBuilderModuleNotLoadedError'
-            errorCategory = 'InvalidArgument'
-            errorMessage  = $($LocalizedData.LabBuilderModuleNotLoadedError)
-        }
-        New-LabException @exceptionParameters
-    }
-
-    if ([System.String]::IsNullOrEmpty($module.Path))
-    {
-        $exceptionParameters = @{
-            errorId       = 'LabBuilderModulePathNullError'
-            errorCategory = 'InvalidArgument'
-            errorMessage  = $($LocalizedData.LabBuilderModulePathNullError)
-        }
-        New-LabException @exceptionParameters
-    }
-
-    return Split-Path -Path $module.Path -Parent
+    return $script:LabBuidlerModuleRoot
 }

--- a/src/lib/private/Update-LabDSC.ps1
+++ b/src/lib/private/Update-LabDSC.ps1
@@ -109,9 +109,9 @@ function Update-LabDSC
         }
 
         $module = ($installedModules |
-                Where-Object -FilterScript $filterScript |
-                Sort-Object -Property Version -Descending |
-                Select-Object -First 1)
+            Where-Object -FilterScript $filterScript |
+            Sort-Object -Property Version -Descending |
+            Select-Object -First 1)
 
         if ($module)
         {
@@ -227,9 +227,9 @@ function Update-LabDSC
         }
 
         # Remove any old self-signed certifcates for this VM
-        Get-ChildItem -Path cert:\LocalMachine\My `
-            | Where-Object { $_.FriendlyName -eq $Script:DSCCertificateFriendlyName } `
-            | Remove-Item
+        Get-ChildItem -Path cert:\LocalMachine\My |
+            Where-Object { $_.FriendlyName -eq $Script:DSCCertificateFriendlyName } |
+            Remove-Item
     } # if
 
     # Add the VM Self-Signed Certificate to the Local Machine store and get the Thumbprint
@@ -294,6 +294,7 @@ function Update-LabDSC
         # Find the location of the line containing "Node $AllNodes.NodeName {"
         [System.String] $Regex = '\s*Node\s.*{.*'
         $Matches = [regex]::matches($dscConfigContent, $Regex, 'IgnoreCase')
+
         if ($Matches.Count -eq 1)
         {
             $dscConfigContent = $dscConfigContent.`

--- a/src/lib/private/Update-LabDSC.ps1
+++ b/src/lib/private/Update-LabDSC.ps1
@@ -251,7 +251,7 @@ function Update-LabDSC
     Write-LabMessage -Message $($LocalizedData.DSCConfigCreatingLCMMOFMessage -f $dscMOFMetaFile, $VM.Name)
 
     $null = ConfigLCM `
-        -OutputPath $($ENV:Temp) `
+        -OutputPath $ENV:Temp `
         -ComputerName $($VM.ComputerName) `
         -Thumbprint $certificateThumbprint
 
@@ -357,7 +357,7 @@ function Update-LabDSC
 
     # Generate the MOF file from the configuration
     $null = & $dscConfigName `
-        -OutputPath $($ENV:Temp) `
+        -OutputPath $ENV:Temp `
         -ConfigurationData $dscConfigData `
         -ErrorAction Stop
 

--- a/src/lib/public/Get-LabVMTemplate.ps1
+++ b/src/lib/public/Get-LabVMTemplate.ps1
@@ -212,7 +212,7 @@ function Get-LabVMTemplate
             -ChildPath ([System.IO.Path]::GetFileName($VMTemplate.vhd))
 
         # Write any template specific default VM attributes
-        [Int64] $MemoryStartupBytes = 1GB
+        [System.Int64] $MemoryStartupBytes = 1GB
         if ($Template.MemoryStartupBytes)
         {
             $MemoryStartupBytes = (Invoke-Expression $Template.MemoryStartupBytes)

--- a/src/lib/public/Get-LabVm.ps1
+++ b/src/lib/public/Get-LabVm.ps1
@@ -602,16 +602,16 @@ function Get-LabVM
                         Look the ISO up in the ISO Resources
                         Pull the list of Resource ISOs available if not already pulled from Lab.
                     #>
-                    if (-not $ResourceISOs)
+                    if (-not $resourceISOs)
                     {
-                        $ResourceISOs = Get-LabResourceISO `
+                        $resourceISOs = Get-LabResourceISO `
                             -Lab $Lab
                     } # if
 
                     # Lookup the Resource ISO record
-                    $ResourceISO = $ResourceISOs | Where-Object -Property Name -eq $vmDVDDrive.ISO
+                    $resourceISO = $resourceISOs | Where-Object -Property Name -eq $vmDVDDrive.ISO
 
-                    if (-not $ResourceISO)
+                    if (-not $resourceISO)
                     {
                         # The ISO Resource was not found
                         $exceptionParameters = @{
@@ -625,7 +625,7 @@ function Get-LabVM
 
                     # The ISO resource was found so populate the ISO details
                     $newDVDDrive.ISO = $vmDVDDrive.ISO
-                    $newDVDDrive.Path = $ResourceISO.Path
+                    $newDVDDrive.Path = $resourceISO.Path
                 } # if
 
                 $dvdDrives += @( $newDVDDrive )

--- a/src/lib/public/Get-LabVm.ps1
+++ b/src/lib/public/Get-LabVm.ps1
@@ -12,40 +12,42 @@ function Get-LabVM
         [Parameter(
             Position=2)]
         [ValidateNotNullOrEmpty()]
-        [System.String[]] $Name,
+        [System.String[]]
+        $Name,
 
         [Parameter(
             Position=3)]
-        [LabVMTemplate[]] $VMTemplates,
+        [LabVMTemplate[]]
+        $vmTemplates,
 
         [Parameter(
             Position=4)]
-        [LabSwitch[]] $Switches
+        [LabSwitch[]]
+        $switches
     )
 
-    # if VMTeplates array not passed, pull it from config.
+    # If VMTeplates array not passed, pull it from config.
     if (-not $PSBoundParameters.ContainsKey('VMTemplates'))
     {
-        [LabVMTemplate[]] $VMTemplates = Get-LabVMTemplate `
+        [LabVMTemplate[]] $vmTemplates = Get-LabVMTemplate `
             -Lab $Lab
     }
 
-    # if Switches array not passed, pull it from config.
+    # If Switches array not passed, pull it from config.
     if (-not $PSBoundParameters.ContainsKey('Switches'))
     {
-        [LabSwitch[]] $Switches = Get-LabSwitch `
+        [LabSwitch[]] $switches = Get-LabSwitch `
             -Lab $Lab
     }
 
-    [LabVM[]] $LabVMs = @()
-    [System.String] $LabPath = $Lab.labbuilderconfig.settings.labpath
-    [System.String] $VHDParentPath = $Lab.labbuilderconfig.settings.vhdparentpathfull
-    [System.String] $LabId = $Lab.labbuilderconfig.settings.labid
-    $VMs = $Lab.labbuilderconfig.vms.vm
+    [LabVM[]] $labVMs = @()
+    [System.String] $labPath = $Lab.labbuilderconfig.settings.labpath
+    [System.String] $labId = $Lab.labbuilderconfig.settings.labid
+    $vms = $Lab.labbuilderconfig.vms.vm
 
-    foreach ($VM in $VMs)
+    foreach ($vm in $vms)
     {
-        if ($VM.Name -eq 'VM')
+        if ($vm.Name -eq 'VM')
         {
             $exceptionParameters = @{
                 errorId = 'VMNameError'
@@ -56,500 +58,550 @@ function Get-LabVM
         } # if
 
         # Get the Instance Count attribute
-        $InstanceCount = $VM.InstanceCount
-        if (-not $InstanceCount)
+        $instanceCount = $vm.InstanceCount
+
+        if (-not $instanceCount)
         {
-            $InstanceCount = 1
+            $instanceCount = 1
         }
 
-        foreach ($Instance in 1..$InstanceCount)
+        foreach ($instance in 1..$instanceCount)
         {
             # If InstanceCount is 1 then don't increment the IP or MAC addresses or append count to the name
-            if ($InstanceCount -eq 1)
+            if ($instanceCount -eq 1)
             {
-                $VMName = $VM.Name
-                $ComputerName = $VM.ComputerName
-                $IncNetIds = 0
+                $vmName = $vm.Name
+                $computerName = $vm.ComputerName
+                $incNetIds = 0
             }
             else
             {
-                $VMName = "$($VM.Name)$Instance"
-                $ComputerName = "$($VM.ComputerName)$Instance"
+                $vmName = "$($vm.Name)$instance"
+                $computerName = "$($vm.ComputerName)$instance"
                 # This value is used to increment IP and MAC addresses
-                $IncNetIds = $Instance - 1
+                $incNetIds = $instance - 1
             } # if
 
-            if ($Name -and ($VMName -notin $Name))
+            if ($Name -and ($vmName -notin $Name))
             {
                 # A names list was passed but this VM wasn't included
                 continue
             } # if
 
-            # if a LabId is set for the lab, prepend it to the VM name.
-            if ($LabId)
+            # If a LabId is set for the lab, prepend it to the VM name.
+            if ($labId)
             {
-                $VMName = "$LabId$VMName"
+                $vmName = "$labId$vmName"
             }
 
-            if (-not $VM.Template)
+            if (-not $vm.Template)
             {
                 $exceptionParameters = @{
                     errorId = 'VMTemplateNameEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNameEmptyError `
-                        -f $VMName)
+                        -f $vmName)
                 }
                 New-LabException @exceptionParameters
             } # if
 
             # Find the template that this VM uses and get the VHD Path
-            [System.String] $ParentVHDPath = ''
-            [System.Boolean] $Found = $false
-            foreach ($VMTemplate in $VMTemplates) {
-                if ($VMTemplate.Name -eq $VM.Template) {
-                    $ParentVHDPath = $VMTemplate.ParentVHD
-                    $Found = $true
+            [System.String] $parentVHDPath = ''
+            [System.Boolean] $found = $false
+
+            foreach ($vmTemplate in $vmTemplates) {
+                if ($vmTemplate.Name -eq $vm.Template) {
+                    $parentVHDPath = $vmTemplate.ParentVHD
+                    $found = $true
                     Break
                 } # if
             } # foreach
 
-            if (-not $Found)
+            if (-not $found)
             {
                 $exceptionParameters = @{
                     errorId = 'VMTemplateNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNotFoundError `
-                        -f $VMName,$VM.template)
+                        -f $vmName,$vm.template)
                 }
                 New-LabException @exceptionParameters
             } # if
 
             # Get path to Offline Domain Join file if it exists
-            [System.String]$NanoODJPath = $null
-            if ($VM.NanoODJPath)
+            [System.String] $nanoODJPath = $null
+
+            if ($vm.NanoODJPath)
             {
-                $NanoODJPath = $VM.NanoODJPath
+                $nanoODJPath = $vm.NanoODJPath
             } # if
 
             # Assemble the Network adapters that this VM will use
-            [LabVMAdapter[]] $VMAdapters = @()
-            [System.Int32] $AdapterCount = 0
-            foreach ($VMAdapter in $VM.Adapters.Adapter)
+            [LabVMAdapter[]] $vmAdapters = @()
+            [System.Int32] $adapterCount = 0
+
+            foreach ($vmAdapter in $vm.Adapters.Adapter)
             {
-                $AdapterCount++
-                $AdapterName = $VMAdapter.Name
-                $AdapterSwitchName = $VMAdapter.SwitchName
-                if ($AdapterName -eq 'adapter')
+                $adapterCount++
+                $adapterName = $vmAdapter.Name
+                $adapterSwitchName = $vmAdapter.SwitchName
+
+                if ($adapterName -eq 'adapter')
                 {
                     $exceptionParameters = @{
                         errorId = 'VMAdapterNameError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.VMAdapterNameError `
-                            -f $VMName)
+                            -f $vmName)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
-                if (-not $AdapterSwitchName)
+                if (-not $adapterSwitchName)
                 {
                     $exceptionParameters = @{
                         errorId = 'VMAdapterSwitchNameError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.VMAdapterSwitchNameError `
-                            -f $VMName,$AdapterName)
+                            -f $vmName,$adapterName)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
-                # if a LabId is set for the lab, prepend it to the adapter name
-                # name and switch name.
-                if ($LabId)
+                <#
+                    If a LabId is set for the lab, prepend it to the adapter name
+                    name and switch name.
+                #>
+                if ($labId)
                 {
-                    $AdapterName = "$LabId$AdapterName"
-                    $AdapterSwitchName = "$LabId$AdapterSwitchName"
+                    $adapterName = "$labId$adapterName"
+                    $adapterSwitchName = "$labId$adapterSwitchName"
                 } # if
 
                 # Check the switch is in the switch list
-                [System.Boolean] $Found = $false
-                foreach ($Switch in $Switches)
+                $found = $false
+
+                foreach ($switch in $switches)
                 {
-                    # Match the switch name to the Adapter Switch Name or
-                    # the LabId and Adapter Switch Name
-                    if ($Switch.Name -eq $AdapterSwitchName)
+                    <#
+                        Match the switch name to the Adapter Switch Name or
+                        the LabId and Adapter Switch Name
+                    #>
+                    if ($switch.Name -eq $adapterSwitchName)
                     {
                         # The switch is found in the switch list - record the VLAN (if there is one)
-                        $Found = $true
-                        $SwitchVLan = $Switch.Vlan
-                        Break
+                        $found = $true
+                        $switchVLan = $switch.Vlan
+                        break
                     } # if
-                    elseif ($Switch.Name -eq $VMAdapter.SwitchName)
+                    elseif ($switch.Name -eq $vmAdapter.SwitchName)
                     {
                         # The switch is found in the switch list - record the VLAN (if there is one)
-                        $Found = $true
-                        $SwitchVLan = $Switch.Vlan
-                        if ($Switch.Type -eq [LabSwitchType]::External)
+                        $found = $true
+                        $switchVLan = $switch.Vlan
+
+                        if ($switch.Type -eq [LabSwitchType]::External)
                         {
-                            $AdapterName = $VMAdapter.Name
-                            $AdapterSwitchName = $VMAdapter.SwitchName
+                            $adapterName = $vmAdapter.Name
+                            $adapterSwitchName = $vmAdapter.SwitchName
                         } # if
-                        Break
+
+                        break
                     }
                 } # foreach
-                if (-not $Found)
+
+                if (-not $found)
                 {
                     $exceptionParameters = @{
                         errorId = 'VMAdapterSwitchNotFoundError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.VMAdapterSwitchNotFoundError `
-                            -f $VMName,$AdapterName,$AdapterSwitchName)
+                            -f $vmName,$adapterName,$adapterSwitchName)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
                 # Figure out the VLan - If defined in the VM use it, otherwise use the one defined in the Switch, otherwise keep blank.
-                [System.String] $VLan = $VMAdapter.VLan
-                if (-not $VLan)
+                [System.String] $vLan = $vmAdapter.VLan
+
+                if (-not $vLan)
                 {
-                    $VLan = $SwitchVLan
+                    $vLan = $switchVLan
                 } # if
 
-                [System.Boolean] $MACAddressSpoofing = ($VMAdapter.macaddressspoofing -eq 'On')
+                [System.Boolean] $MACAddressSpoofing = ($vmAdapter.macaddressspoofing -eq 'On')
 
                 # Have we got any IPv4 settings?
                 Remove-Variable -Name IPv4 -ErrorAction SilentlyContinue
-                if ($VMAdapter.IPv4)
+
+                if ($vmAdapter.IPv4)
                 {
-                    if ($VMAdapter.IPv4.Address)
+                    if ($vmAdapter.IPv4.Address)
                     {
-                        $IPv4 = [LabVMAdapterIPv4]::New(`
+                        $ipv4 = [LabVMAdapterIPv4]::New(`
                             (Get-LabNextIpAddress `
-                                -IpAddress $VMAdapter.IPv4.Address`
-                                -Step $IncNetIds)`
-                            ,$VMAdapter.IPv4.SubnetMask)
+                                -IpAddress $vmAdapter.IPv4.Address`
+                                -Step $incNetIds)`
+                            ,$vmAdapter.IPv4.SubnetMask)
                     } # if
-                    $IPv4.defaultgateway = $VMAdapter.IPv4.DefaultGateway
-                    $IPv4.dnsserver = $VMAdapter.IPv4.DNSServer
+
+                    $ipv4.defaultgateway = $vmAdapter.IPv4.DefaultGateway
+                    $ipv4.dnsserver = $vmAdapter.IPv4.DNSServer
                 } # if
 
                 # Have we got any IPv6 settings?
                 Remove-Variable -Name IPv6 -ErrorAction SilentlyContinue
-                if ($VMAdapter.IPv6)
+
+                if ($vmAdapter.IPv6)
                 {
-                    if ($VMAdapter.IPv6.Address)
+                    if ($vmAdapter.IPv6.Address)
                     {
-                        $IPv6 = [LabVMAdapterIPv6]::New(`
+                        $ipv6 = [LabVMAdapterIPv6]::New(`
                             (Get-LabNextIpAddress `
-                                -IpAddress $VMAdapter.IPv6.Address`
-                                -Step $IncNetIds)`
-                            ,$VMAdapter.IPv6.SubnetMask)
+                                -IpAddress $vmAdapter.IPv6.Address`
+                                -Step $incNetIds)`
+                            ,$vmAdapter.IPv6.SubnetMask)
                     } # if
-                    $IPv6.defaultgateway = $VMAdapter.IPv6.DefaultGateway
-                    $IPv6.dnsserver = $VMAdapter.IPv6.DNSServer
+
+                    $ipv6.defaultgateway = $vmAdapter.IPv6.DefaultGateway
+                    $ipv6.dnsserver = $vmAdapter.IPv6.DNSServer
                 } # if
 
-                $NewVMAdapter = [LabVMAdapter]::New($AdapterName)
-                $NewVMAdapter.SwitchName = $AdapterSwitchName
-                if($VMAdapter.macaddress)
+                $newVMAdapter = [LabVMAdapter]::New($adapterName)
+                $newVMAdapter.SwitchName = $adapterSwitchName
+
+                if ($vmAdapter.macaddress)
                 {
-                    $NewVMAdapter.MACAddress = Get-NextMacAddress `
-                        -MacAddress $VMAdapter.macaddress `
-                        -Step $IncNetIds
+                    $newVMAdapter.MACAddress = Get-NextMacAddress `
+                        -MacAddress $vmAdapter.macaddress `
+                        -Step $incNetIds
                 } # if
-                $NewVMAdapter.MACAddressSpoofing = $MACAddressSpoofing
-                $NewVMAdapter.VLan = $VLan
-                $NewVMAdapter.IPv4 = $IPv4
-                $NewVMAdapter.IPv6 = $IPv6
-                $VMAdapters += @( $NewVMAdapter )
+
+                $newVMAdapter.MACAddressSpoofing = $MACAddressSpoofing
+                $newVMAdapter.VLan = $vLan
+                $newVMAdapter.IPv4 = $ipv4
+                $newVMAdapter.IPv6 = $ipv6
+                $vmAdapters += @( $newVMAdapter )
             } # foreach
 
             # Assemble the Data Disks this VM will use
-            [LabDataVHD[]] $DataVhds = @()
-            [System.Int32] $DataVhdCount = 0
-            foreach ($VMDataVhd in $VM.DataVhds.DataVhd)
+            [LabDataVHD[]] $dataVhds = @()
+            [System.Int32] $dataVhdCount = 0
+
+            foreach ($vmDataVhd in $vm.DataVhds.DataVhd)
             {
-                $DataVhdCount++
+                $dataVhdCount++
 
                 # Load all the VHD properties and check they are valid
-                [System.String] $Vhd = $VMDataVhd.Vhd
-                if (-not $VMDataVhd.Vhd)
+                [System.String] $vhd = $vmDataVhd.Vhd
+
+                if (-not $vmDataVhd.Vhd)
                 {
                     $exceptionParameters = @{
                         errorId = 'VMDataDiskVHDEmptyError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.VMDataDiskVHDEmptyError `
-                            -f $VMName)
+                            -f $vmName)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
-                # Adjust the path to be relative to the Virtual Hard Disks folder of the VM
-                # if it doesn't contain a root (e.g. c:\)
-                if (-not [System.IO.Path]::IsPathRooted($Vhd))
+                <#
+                    Adjust the path to be relative to the Virtual Hard Disks folder of the VM
+                    if it doesn't contain a root (e.g. c:\)
+                #>
+                if (-not [System.IO.Path]::IsPathRooted($vhd))
                 {
-                    $Vhd = Join-Path `
-                        -Path $LabPath `
-                        -ChildPath "$($VMName)\Virtual Hard Disks\$Vhd"
+                    $vhd = Join-Path `
+                        -Path $labPath `
+                        -ChildPath "$($vmName)\Virtual Hard Disks\$vhd"
                 } # if
 
                 # Does the VHD already exist?
-                $Exists = Test-Path `
-                    -Path $Vhd
+                $exists = Test-Path `
+                    -Path $vhd
 
                 # Create the new Data VHD object
-                $NewDataVHD = [LabDataVHD]::New($Vhd)
+                $newDataVHD = [LabDataVHD]::New($vhd)
 
                 # Get the Parent VHD and check it exists if passed
-                if ($VMDataVhd.ParentVHD)
+                if ($vmDataVhd.ParentVHD)
                 {
-                    $NewDataVHD.ParentVhd = $VMDataVhd.ParentVHD
-                    # Adjust the path to be relative to the Virtual Hard Disks folder of the VM
-                    # if it doesn't contain a root (e.g. c:\)
-                    if (-not [System.IO.Path]::IsPathRooted($NewDataVHD.ParentVhd))
+                    $newDataVHD.ParentVhd = $vmDataVhd.ParentVHD
+                    <#
+                        Adjust the path to be relative to the Virtual Hard Disks folder of the VM
+                        if it doesn't contain a root (e.g. c:\)
+                    #>
+                    if (-not [System.IO.Path]::IsPathRooted($newDataVHD.ParentVhd))
                     {
-                        $NewDataVHD.ParentVhd = Join-Path `
+                        $newDataVHD.ParentVhd = Join-Path `
                             -Path $Lab.labbuilderconfig.settings.fullconfigpath `
-                            -ChildPath $NewDataVHD.ParentVhd
+                            -ChildPath $newDataVHD.ParentVhd
                     }
-                    if (-not (Test-Path -Path $NewDataVHD.ParentVhd))
+
+                    if (-not (Test-Path -Path $newDataVHD.ParentVhd))
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskParentVHDNotFoundError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskParentVHDNotFoundError `
-                                -f $VMName,$NewDataVHD.ParentVhd)
+                                -f $vmName,$newDataVHD.ParentVhd)
                         }
                         New-LabException @exceptionParameters
                     } # if
                 } # if
 
                 # Get the Source VHD and check it exists if passed
-                if ($VMDataVhd.SourceVHD)
+                if ($vmDataVhd.SourceVHD)
                 {
-                    $NewDataVHD.SourceVhd = $VMDataVhd.SourceVHD
-                    # Adjust the path to be relative to the Virtual Hard Disks folder of the VM
-                    # if it doesn't contain a root (e.g. c:\)
-                    if (-not [System.IO.Path]::IsPathRooted($NewDataVHD.SourceVhd))
+                    $newDataVHD.SourceVhd = $vmDataVhd.SourceVHD
+                    <#
+                        Adjust the path to be relative to the Virtual Hard Disks folder of the VM
+                        if it doesn't contain a root (e.g. c:\)
+                    #>
+                    if (-not [System.IO.Path]::IsPathRooted($newDataVHD.SourceVhd))
                     {
-                        $NewDataVHD.SourceVhd = Join-Path `
+                        $newDataVHD.SourceVhd = Join-Path `
                             -Path $Lab.labbuilderconfig.settings.fullconfigpath `
-                            -ChildPath $NewDataVHD.SourceVhd
+                            -ChildPath $newDataVHD.SourceVhd
                     } # if
-                    if (-not (Test-Path -Path $NewDataVHD.SourceVhd))
+
+                    if (-not (Test-Path -Path $newDataVHD.SourceVhd))
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskSourceVHDNotFoundError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskSourceVHDNotFoundError `
-                                -f $VMName,$NewDataVHD.SourceVhd)
+                                -f $vmName,$newDataVHD.SourceVhd)
                         }
                         New-LabException @exceptionParameters
                     } # if
                 } # if
 
                 # Get the disk size if provided
-                if ($VMDataVhd.Size)
+                if ($vmDataVhd.Size)
                 {
-                    $NewDataVHD.Size = (Invoke-Expression $VMDataVhd.Size)
+                    $newDataVHD.Size = (Invoke-Expression -Command $vmDataVhd.Size)
                 } # if
 
                 # Get the Shared flag
-                $NewDataVHD.Shared = ($VMDataVhd.Shared -eq 'Y')
+                $newDataVHD.Shared = ($vmDataVhd.Shared -eq 'Y')
 
                 # Get the Support Persistent Reservations
-                $NewDataVHD.SupportPR = ($VMDataVhd.SupportPR -eq 'Y')
+                $newDataVHD.SupportPR = ($vmDataVhd.SupportPR -eq 'Y')
+
                 # Validate the data disk type specified
-                if ($VMDataVhd.Type)
+                if ($vmDataVhd.Type)
                 {
-                    switch ($VMDataVhd.Type)
+                    switch ($vmDataVhd.Type)
                     {
                         'fixed'
                         {
-                            break;
+                            break
                         }
+
                         'dynamic'
                         {
-                            break;
+                            break
                         }
+
                         'differencing'
                         {
-                            if (-not $NewDataVHD.ParentVhd)
+                            if (-not $newDataVHD.ParentVhd)
                             {
                                 $exceptionParameters = @{
                                     errorId = 'VMDataDiskParentVHDMissingError'
                                     errorCategory = 'InvalidArgument'
                                     errorMessage = $($LocalizedData.VMDataDiskParentVHDMissingError `
-                                        -f $VMName)
+                                        -f $vmName)
                                 }
                                 New-LabException @exceptionParameters
                             } # if
-                            if ($NewDataVHD.Shared)
+
+                            if ($newDataVHD.Shared)
                             {
                                 $exceptionParameters = @{
                                     errorId = 'VMDataDiskSharedDifferencingError'
                                     errorCategory = 'InvalidArgument'
                                     errorMessage = $($LocalizedData.VMDataDiskSharedDifferencingError `
-                                        -f $VMName,$VHD)
+                                        -f $vmName,$VHD)
                                 }
                                 New-LabException @exceptionParameters
                             } # if
+
+                            break
                         }
-                        Default
+
+                        default
                         {
                             $exceptionParameters = @{
                                 errorId = 'VMDataDiskUnknownTypeError'
                                 errorCategory = 'InvalidArgument'
                                 errorMessage = $($LocalizedData.VMDataDiskUnknownTypeError `
-                                    -f $VMName,$VHD,$VMDataVhd.Type)
+                                    -f $vmName,$VHD,$vmDataVhd.Type)
                             }
                             New-LabException @exceptionParameters
                         }
                     } # switch
-                    $NewDataVHD.VHDType = [LabVHDType]::$($VMDataVhd.Type)
+
+                    $newDataVHD.VHDType = [LabVHDType]::$($vmDataVhd.Type)
                 } # if
 
                 # Get Partition Style for the new disk.
-                if ($VMDataVhd.PartitionStyle)
+                if ($vmDataVhd.PartitionStyle)
                 {
-                    $PartitionStyle = [LabPartitionStyle]::$($VMDataVhd.PartitionStyle)
+                    $PartitionStyle = [LabPartitionStyle]::$($vmDataVhd.PartitionStyle)
+
                     if (-not $PartitionStyle)
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskPartitionStyleError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskPartitionStyleError `
-                                -f $VMName,$VHD,$VMDataVhd.PartitionStyle)
+                                -f $vmName,$VHD,$vmDataVhd.PartitionStyle)
                         }
                         New-LabException @exceptionParameters
                     } # if
-                    $NewDataVHD.PartitionStyle = $PartitionStyle
+                    $newDataVHD.PartitionStyle = $PartitionStyle
                 } # if
 
                 # Get file system for the new disk.
-                if ($VMDataVhd.FileSystem)
+                if ($vmDataVhd.FileSystem)
                 {
-                    $FileSystem = [LabFileSystem]::$($VMDataVhd.FileSystem)
+                    $FileSystem = [LabFileSystem]::$($vmDataVhd.FileSystem)
+
                     if (-not $FileSystem)
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskFileSystemError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskFileSystemError `
-                                -f $VMName,$VHD,$VMDataVhd.FileSystem)
+                                -f $vmName,$VHD,$vmDataVhd.FileSystem)
                         }
                         New-LabException @exceptionParameters
                     } # if
-                    $NewDataVHD.FileSystem = $FileSystem
+                    $newDataVHD.FileSystem = $FileSystem
                 } # if
 
                 # Has a file system label been provided?
-                if ($VMDataVhd.FileSystemLabel)
+                if ($vmDataVhd.FileSystemLabel)
                 {
-                    $NewDataVHD.FileSystemLabel = $VMDataVhd.FileSystemLabel
+                    $newDataVHD.FileSystemLabel = $vmDataVhd.FileSystemLabel
                 } # if
 
-                # if the Partition Style, File System or File System Label has been
-                # provided then ensure Partition Style and File System are set.
-                if ($NewDataVHD.PartitionStyle `
-                    -or $NewDataVHD.FileSystem `
-                    -or $NewDataVHD.FileSystemLabel)
+                <#
+                    If the Partition Style, File System or File System Label has been
+                    provided then ensure Partition Style and File System are set.
+                #>
+                if ($newDataVHD.PartitionStyle `
+                    -or $newDataVHD.FileSystem `
+                    -or $newDataVHD.FileSystemLabel)
                 {
-                    if (-not $NewDataVHD.PartitionStyle)
+                    if (-not $newDataVHD.PartitionStyle)
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskPartitionStyleMissingError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskPartitionStyleMissingError `
-                                -f $VMName,$VHD)
+                                -f $vmName,$VHD)
                         }
                         New-LabException @exceptionParameters
                     } # if
-                    if (-not $NewDataVHD.FileSystem)
+
+                    if (-not $newDataVHD.FileSystem)
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskFileSystemMissingError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskFileSystemMissingError `
-                                -f $VMName,$VHD)
+                                -f $vmName,$VHD)
                         }
                         New-LabException @exceptionParameters
                     } # if
                 } # if
 
                 # Get the Folder to copy and check it exists if passed
-                if ($VMDataVhd.CopyFolders)
+                if ($vmDataVhd.CopyFolders)
                 {
-                    foreach ($CopyFolder in ($VMDataVhd.CopyFolders -Split ','))
+                    foreach ($CopyFolder in ($vmDataVhd.CopyFolders -Split ','))
                     {
-                        # Adjust the path to be relative to the configuration folder
-                        # if it doesn't contain a root (e.g. c:\)
+                        <#
+                            Adjust the path to be relative to the configuration folder
+                            if it doesn't contain a root (e.g. c:\)
+                        #>
                         if (-not [System.IO.Path]::IsPathRooted($CopyFolder))
                         {
                             $CopyFolder = Join-Path `
                                 -Path $Lab.labbuilderconfig.settings.fullconfigpath `
                                 -ChildPath $CopyFolder
                         } # if
+
                         if (-not (Test-Path -Path $CopyFolder -Type Container))
                         {
-                        $exceptionParameters = @{
-                            errorId = 'VMDataDiskCopyFolderMissingError'
-                            errorCategory = 'InvalidArgument'
-                            errorMessage = $($LocalizedData.VMDataDiskCopyFolderMissingError `
-                                -f $VMName,$VHD,$CopyFolder)
-                            }
-                        New-LabException @exceptionParameters
+                            $exceptionParameters = @{
+                                errorId = 'VMDataDiskCopyFolderMissingError'
+                                errorCategory = 'InvalidArgument'
+                                errorMessage = $($LocalizedData.VMDataDiskCopyFolderMissingError `
+                                    -f $vmName,$VHD,$CopyFolder)
+                                }
+                            New-LabException @exceptionParameters
                         }
                     } # foreach
-                    $NewDataVHD.CopyFolders = $VMDataVhd.CopyFolders
+
+                    $newDataVHD.CopyFolders = $vmDataVhd.CopyFolders
                 } # if
 
                 # Should the Source VHD be moved rather than copied
-                if ($VMDataVhd.MoveSourceVHD)
+                if ($vmDataVhd.MoveSourceVHD)
                 {
-                    $NewDataVHD.MoveSourceVHD = ($VMDataVhd.MoveSourceVHD -eq 'Y')
-                    if (-not $NewDataVHD.SourceVHD)
+                    $newDataVHD.MoveSourceVHD = ($vmDataVhd.MoveSourceVHD -eq 'Y')
+                    if (-not $newDataVHD.SourceVHD)
                     {
                         $exceptionParameters = @{
                             errorId = 'VMDataDiskSourceVHDIfMoveError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDataDiskSourceVHDIfMoveError `
-                                -f $VMName,$VHD)
+                                -f $vmName,$VHD)
                         }
                         New-LabException @exceptionParameters
                     } # if
                 } # if
 
                 # if the data disk file doesn't exist then some basic parameters MUST be provided
-                if (-not $Exists `
-                    -and ( ( ( -not $NewDataVHD.VhdType ) -or ( $NewDataVHD.Size -eq 0) ) `
-                    -and -not $NewDataVHD.SourceVhd ) )
+                if (-not $exists `
+                    -and ( ( ( -not $newDataVHD.VhdType ) -or ( $newDataVHD.Size -eq 0) ) `
+                    -and -not $newDataVHD.SourceVhd ) )
                 {
                     $exceptionParameters = @{
                         errorId = 'VMDataDiskCantBeCreatedError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                            -f $VMName,$VHD)
+                            -f $vmName,$VHD)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
-                $DataVHDs += @( $NewDataVHD )
+                $dataVHDs += @( $newDataVHD )
             } # foreach
 
             # Assemble the DVD Drives this VM will use
-            [LabDVDDrive[]] $DVDDrives = @()
-            [System.Int32] $DVDDriveCount = 0
-            foreach ($VMDVDDrive in $VM.DVDDrives.DVDDrive)
+            [LabDVDDrive[]] $dvdDrives = @()
+            [System.Int32] $dvdDriveCount = 0
+
+            foreach ($vmDVDDrive in $vm.DVDDrives.DVDDrive)
             {
-                $DVDDriveCount++
+                $dvdDriveCount++
 
                 # Create the new DVD Drive object
-                $NewDVDDrive = [LabDVDDRive]::New()
+                $newDVDDrive = [LabDVDDRive]::New()
 
                 # Load all the DVD Drive properties and check they are valid
-                if ($VMDVDDrive.ISO)
+                if ($vmDVDDrive.ISO)
                 {
-                    # Look the ISO up in the ISO Resources
-                    # Pull the list of Resource ISOs available if not already pulled from Lab.
+                    <#
+                        Look the ISO up in the ISO Resources
+                        Pull the list of Resource ISOs available if not already pulled from Lab.
+                    #>
                     if (-not $ResourceISOs)
                     {
                         $ResourceISOs = Get-LabResourceISO `
@@ -557,7 +609,8 @@ function Get-LabVM
                     } # if
 
                     # Lookup the Resource ISO record
-                    $ResourceISO = $ResourceISOs | Where-Object -Property Name -eq $VMDVDDrive.ISO
+                    $ResourceISO = $ResourceISOs | Where-Object -Property Name -eq $vmDVDDrive.ISO
+
                     if (-not $ResourceISO)
                     {
                         # The ISO Resource was not found
@@ -565,346 +618,372 @@ function Get-LabVM
                             errorId = 'VMDVDDriveISOResourceNotFOundError'
                             errorCategory = 'InvalidArgument'
                             errorMessage = $($LocalizedData.VMDVDDriveISOResourceNotFOundError `
-                                -f $VMName,$VMDVDDrive.ISO)
+                                -f $vmName,$vmDVDDrive.ISO)
                         }
                         New-LabException @exceptionParameters
                     } # if
+
                     # The ISO resource was found so populate the ISO details
-                    $NewDVDDrive.ISO = $VMDVDDrive.ISO
-                    $NewDVDDrive.Path = $ResourceISO.Path
+                    $newDVDDrive.ISO = $vmDVDDrive.ISO
+                    $newDVDDrive.Path = $ResourceISO.Path
                 } # if
 
-                $DVDDrives += @( $NewDVDDrive )
+                $dvdDrives += @( $newDVDDrive )
             } # foreach
 
             # Does the VM have an Unattend file specified?
-            [System.String] $UnattendFile = ''
-            if ($VM.UnattendFile)
+            $unattendFile = ''
+
+            if ($vm.UnattendFile)
             {
-                if ([System.IO.Path]::IsPathRooted($VM.UnattendFile))
+                if ([System.IO.Path]::IsPathRooted($vm.UnattendFile))
                 {
-                    $UnattendFile = $VM.UnattendFile
+                    $unattendFile = $vm.UnattendFile
                 }
                 else
                 {
-                    $UnattendFile = Join-Path `
+                    $unattendFile = Join-Path `
                         -Path $Lab.labbuilderconfig.settings.fullconfigpath `
-                        -ChildPath $VM.UnattendFile
+                        -ChildPath $vm.UnattendFile
                 } # if
-                if (-not (Test-Path $UnattendFile))
+
+                if (-not (Test-Path $unattendFile))
                 {
                     $exceptionParameters = @{
                         errorId = 'UnattendFileMissingError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.UnattendFileMissingError `
-                            -f $VMName,$UnattendFile)
+                            -f $vmName,$unattendFile)
                     }
                     New-LabException @exceptionParameters
                 } # if
             } # if
 
             # Does the VM specify a Setup Complete Script?
-            [System.String] $SetupComplete = ''
-            if ($VM.SetupComplete)
+            $setupComplete = ''
+
+            if ($vm.SetupComplete)
             {
-                if ([System.IO.Path]::IsPathRooted($VM.SetupComplete))
+                if ([System.IO.Path]::IsPathRooted($vm.SetupComplete))
                 {
-                    $SetupComplete = $VM.SetupComplete
+                    $setupComplete = $vm.SetupComplete
                 }
                 else
                 {
-                    $SetupComplete = Join-Path `
+                    $setupComplete = Join-Path `
                         -Path $Lab.labbuilderconfig.settings.fullconfigpath `
-                        -ChildPath $VM.SetupComplete
+                        -ChildPath $vm.SetupComplete
                 } # if
-                if ([System.IO.Path]::GetExtension($SetupComplete).ToLower() -notin '.ps1','.cmd' )
+
+                if ([System.IO.Path]::GetExtension($setupComplete).ToLower() -notin '.ps1','.cmd' )
                 {
                     $exceptionParameters = @{
                         errorId = 'SetupCompleteFileBadTypeError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.SetupCompleteFileBadTypeError `
-                            -f $VMName,$SetupComplete)
+                            -f $vmName,$setupComplete)
                     }
                     New-LabException @exceptionParameters
                 } # if
-                if (-not (Test-Path $SetupComplete))
+
+                if (-not (Test-Path $setupComplete))
                 {
                     $exceptionParameters = @{
                         errorId = 'SetupCompleteFileMissingError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.SetupCompleteFileMissingError `
-                            -f $VMName,$SetupComplete)
+                            -f $vmName,$setupComplete)
                     }
                     New-LabException @exceptionParameters
                 } # if
             } # if
 
             # Create the Lab DSC object
-            $LabDSC = [LabDSC]::New($VM.DSC.ConfigName)
+            $labDSC = [LabDSC]::New($vm.DSC.ConfigName)
 
             # Load the DSC Config File setting and check it
-            [System.String] $LabDSC.ConfigFile = ''
-            if ($VM.DSC.ConfigFile)
+            $labDSC.ConfigFile = ''
+
+            if ($vm.DSC.ConfigFile)
             {
-                if (-not [System.IO.Path]::IsPathRooted($VM.DSC.ConfigFile))
+                if (-not [System.IO.Path]::IsPathRooted($vm.DSC.ConfigFile))
                 {
-                    $LabDSC.ConfigFile = Join-Path `
+                    $labDSC.ConfigFile = Join-Path `
                         -Path $Lab.labbuilderconfig.settings.dsclibrarypathfull `
-                        -ChildPath $VM.DSC.ConfigFile
+                        -ChildPath $vm.DSC.ConfigFile
                 }
                 else
                 {
-                    $LabDSC.ConfigFile = $VM.DSC.ConfigFile
+                    $labDSC.ConfigFile = $vm.DSC.ConfigFile
                 } # if
 
-                if ([System.IO.Path]::GetExtension($LabDSC.ConfigFile).ToLower() -ne '.ps1' )
+                if ([System.IO.Path]::GetExtension($labDSC.ConfigFile).ToLower() -ne '.ps1' )
                 {
                     $exceptionParameters = @{
                         errorId = 'DSCConfigFileBadTypeError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.DSCConfigFileBadTypeError `
-                            -f $VMName,$LabDSC.ConfigFile)
+                            -f $vmName,$labDSC.ConfigFile)
                     }
                     New-LabException @exceptionParameters
                 } # if
 
-                if (-not (Test-Path $LabDSC.ConfigFile))
+                if (-not (Test-Path $labDSC.ConfigFile))
                 {
                     $exceptionParameters = @{
                         errorId = 'DSCConfigFileMissingError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.DSCConfigFileMissingError `
-                            -f $VMName,$LabDSC.ConfigFile)
+                            -f $vmName,$labDSC.ConfigFile)
                     }
                     New-LabException @exceptionParameters
                 } # if
-                if (-not $VM.DSC.ConfigName)
+
+                if (-not $vm.DSC.ConfigName)
                 {
                     $exceptionParameters = @{
                         errorId = 'DSCConfigNameIsEmptyError'
                         errorCategory = 'InvalidArgument'
                         errorMessage = $($LocalizedData.DSCConfigNameIsEmptyError `
-                            -f $VMName)
+                            -f $vmName)
                     }
                     New-LabException @exceptionParameters
                 } # if
             } # if
 
             # Load the DSC Parameters
-            [System.String] $LabDSC.Parameters = ''
-            if ($VM.DSC.Parameters)
+            $labDSC.Parameters = ''
+
+            if ($vm.DSC.Parameters)
             {
-                # Correct any LFs into CRLFs to ensure the new line format is the same when
-                # pulled from the XML.
-                $LabDSC.Parameters = ($VM.DSC.Parameters -replace "`r`n","`n") -replace "`n","`r`n"
+                <#
+                    Correct any LFs into CRLFs to ensure the new line format is the same when
+                    pulled from the XML.
+                #>
+                $labDSC.Parameters = ($vm.DSC.Parameters -replace "`r`n","`n") -replace "`n","`r`n"
             } # if
 
             # Load the DSC Parameters
-            [System.Boolean] $LabDSC.Logging = ($VM.DSC.Logging -eq 'Y')
+            $labDSC.Logging = ($vm.DSC.Logging -eq 'Y')
 
             # Get the Memory Startup Bytes (from the template or VM)
-            [Int64] $MemoryStartupBytes = 1GB
-            if ($VM.memorystartupbytes)
+            [System.Int64] $memoryStartupBytes = 1GB
+
+            if ($vm.memorystartupbytes)
             {
-                $MemoryStartupBytes = (Invoke-Expression $VM.memorystartupbytes)
+                $memoryStartupBytes = (Invoke-Expression -Command $vm.memorystartupbytes)
             }
-            elseif ($VMTemplate.memorystartupbytes)
+            elseif ($vmTemplate.memorystartupbytes)
             {
-                $MemoryStartupBytes = $VMTemplate.memorystartupbytes
+                $memoryStartupBytes = $vmTemplate.memorystartupbytes
             } # if
 
             # Get the Dynamic Memory Enabled flag
-            [System.Boolean] $DynamicMemoryEnabled = $true
-            if ($VM.DynamicMemoryEnabled)
+            $dynamicMemoryEnabled = $true
+
+            if ($vm.DynamicMemoryEnabled)
             {
-                $DynamicMemoryEnabled = ($VM.DynamicMemoryEnabled -eq 'Y')
+                $dynamicMemoryEnabled = ($vm.DynamicMemoryEnabled -eq 'Y')
             }
-            elseif ($VMTemplate.DynamicMemoryEnabled)
+            elseif ($vmTemplate.DynamicMemoryEnabled)
             {
-                $DynamicMemoryEnabled = $VMTemplate.DynamicMemoryEnabled
+                $dynamicMemoryEnabled = $vmTemplate.DynamicMemoryEnabled
             } # if
 
             # Get the Number of vCPUs (from the template or VM)
-            [System.Int32] $ProcessorCount = 1
-            if ($VM.processorcount)
+            [System.Int32] $processorCount = 1
+
+            if ($vm.processorcount)
             {
-                $ProcessorCount = (Invoke-Expression $VM.processorcount)
+                $processorCount = (Invoke-Expression $vm.processorcount)
             }
-            elseif ($VMTemplate.processorcount)
+            elseif ($vmTemplate.processorcount)
             {
-                $ProcessorCount = $VMTemplate.processorcount
+                $processorCount = $vmTemplate.processorcount
             } # if
 
             # Get the Expose Virtualization Extensions flag
-            if ($VM.ExposeVirtualizationExtensions)
+            if ($vm.ExposeVirtualizationExtensions)
             {
-                $ExposeVirtualizationExtensions = ($VM.ExposeVirtualizationExtensions -eq 'Y')
+                $exposeVirtualizationExtensions = ($vm.ExposeVirtualizationExtensions -eq 'Y')
             }
-            elseif ($VMTemplate.ExposeVirtualizationExtensions)
+            elseif ($vmTemplate.ExposeVirtualizationExtensions)
             {
-                $ExposeVirtualizationExtensions = $VMTemplate.ExposeVirtualizationExtensions
+                $exposeVirtualizationExtensions = $vmTemplate.ExposeVirtualizationExtensions
             } # if
 
-            # If VM requires ExposeVirtualizationExtensions but
-            # it is not supported on Host then throw an exception.
-            if ($ExposeVirtualizationExtensions -and ($Script:CurrentBuild -lt 10565))
+            <#
+                If VM requires ExposeVirtualizationExtensions but
+                it is not supported on Host then throw an exception.
+            #>
+            if ($exposeVirtualizationExtensions -and ($Script:CurrentBuild -lt 10565))
             {
                 $exceptionParameters = @{
                     errorId = 'VMVirtualizationExtError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMVirtualizationExtError `
-                        -f $VMName)
+                        -f $vmName)
                 }
                 New-LabException @exceptionParameters
             } # if
 
-            [System.Boolean] $UseDifferencingDisk = $true
-            if ($VM.UseDifferencingDisk -eq 'N')
+            $useDifferencingDisk = $true
+
+            if ($vm.UseDifferencingDisk -eq 'N')
             {
-                $UseDifferencingDisk = $false
+                $useDifferencingDisk = $false
             } # if
 
             # Get the Integration Services flags
-            if ($null -ne $VM.IntegrationServices)
+            if ($null -ne $vm.IntegrationServices)
             {
-                $IntegrationServices = $VM.IntegrationServices
+                $integrationServices = $vm.IntegrationServices
             }
-            elseif ($null -ne $VMTemplate.IntegrationServices)
+            elseif ($null -ne $vmTemplate.IntegrationServices)
             {
-                $IntegrationServices = $VMTemplate.IntegrationServices
+                $integrationServices = $vmTemplate.IntegrationServices
             } # if
 
             # Get the Administrator password (from the template or VM)
-            [System.String] $AdministratorPassword = ''
-            if ($VM.administratorpassword)
+            $administratorPassword = ''
+
+            if ($vm.administratorpassword)
             {
-                $AdministratorPassword = $VM.administratorpassword
+                $administratorPassword = $vm.administratorpassword
             }
-            elseif ($VMTemplate.administratorpassword)
+            elseif ($vmTemplate.administratorpassword)
             {
-                $AdministratorPassword = $VMTemplate.administratorpassword
+                $administratorPassword = $vmTemplate.administratorpassword
             } # if
 
             # Get the Product Key (from the template or VM)
-            [System.String] $ProductKey = ''
-            if ($VM.productkey)
+            $productKey = ''
+
+            if ($vm.productkey)
             {
-                $ProductKey = $VM.productkey
+                $productKey = $vm.productkey
             }
-            elseif ($VMTemplate.productkey)
+            elseif ($vmTemplate.productkey)
             {
-                $ProductKey = $VMTemplate.productkey
+                $productKey = $vmTemplate.productkey
             } # if
 
             # Get the Timezone (from the template or VM)
-            [System.String] $Timezone = 'Pacific Standard Time'
-            if ($VM.timezone)
+            $timezone = 'Pacific Standard Time'
+
+            if ($vm.timezone)
             {
-                $Timezone = $VM.timezone
+                $timezone = $vm.timezone
             }
-            elseif ($VMTemplate.timezone)
+            elseif ($vmTemplate.timezone)
             {
-                $Timezone = $VMTemplate.timezone
+                $timezone = $vmTemplate.timezone
             } # if
 
             # Get the OS Type
-            $OSType = [LabOStype]::Server
-            if ($VM.OSType)
+            $osType = [LabOStype]::Server
+
+            if ($vm.OSType)
             {
-                $OSType = $VM.OSType
+                $osType = $vm.OSType
             }
-            elseif ($VMTemplate.OSType)
+            elseif ($vmTemplate.OSType)
             {
-                $OSType = $VMTemplate.OSType
+                $osType = $vmTemplate.OSType
             } # if
 
             # Get the Bootorder
-            [Byte] $Bootorder = [Byte]::MaxValue
-            if ($VM.bootorder)
+            [Byte] $bootorder = [Byte]::MaxValue
+
+            if ($vm.bootorder)
             {
-                $Bootorder = $VM.bootorder
+                $bootorder = $vm.bootorder
             } # if
 
             # Get the Packages
-            [System.String] $Packages = $null
-            if ($VM.packages)
+            [System.String] $packages = $null
+
+            if ($vm.packages)
             {
-                $Packages = $VM.packages
+                $packages = $vm.packages
             }
-            elseif ($VMTemplate.packages)
+            elseif ($vmTemplate.packages)
             {
-                $Packages = $VMTemplate.packages
+                $packages = $vmTemplate.packages
             } # if
 
             # Get the Version (from the template or VM)
-            [System.String] $Version = '8.0'
-            if ($VM.version)
+            $version = '8.0'
+
+            if ($vm.version)
             {
-                $Version = $VM.version
+                $version = $vm.version
             }
-            elseif ($VMTemplate.version)
+            elseif ($vmTemplate.version)
             {
-                $Version = $VMTemplate.version
+                $version = $vmTemplate.version
             } # if
 
             # Get the Generation (from the template or VM)
-            [System.String] $Generation = 2
-            if ($VM.generation)
+            $generation = '2'
+
+            if ($vm.generation)
             {
-                $Generation = $VM.generation
+                $generation = $vm.generation
             }
-            elseif ($VMTemplate.generation)
+            elseif ($vmTemplate.generation)
             {
-                $Generation = $VMTemplate.generation
+                $generation = $vmTemplate.generation
             } # if
 
             # Get the Certificate Source
-            $CertificateSource = [LabCertificateSource]::Guest
-            if ($OSType -eq [LabOSType]::Nano)
+            $certificateSource = [LabCertificateSource]::Guest
+
+            if ($osType -eq [LabOSType]::Nano)
             {
                 # Nano Server can't generate certificates so must always be set to Host
-                $CertificateSource = [LabCertificateSource]::Host
+                $certificateSource = [LabCertificateSource]::Host
             }
-            elseif ($VM.CertificateSource)
+            elseif ($vm.CertificateSource)
             {
-                $CertificateSource = $VM.CertificateSource
+                $certificateSource = $vm.CertificateSource
             } # if
 
 
-            $LabVM = [LabVM]::New($VMName,$ComputerName)
-            $LabVM.Template = $VM.Template
-            $LabVM.ParentVHD = $ParentVHDPath
-            $LabVM.UseDifferencingDisk = $UseDifferencingDisk
-            $LabVM.MemoryStartupBytes = $MemoryStartupBytes
-            $LabVM.DynamicMemoryEnabled = $DynamicMemoryEnabled
-            $LabVM.ProcessorCount = $ProcessorCount
-            $LabVM.ExposeVirtualizationExtensions = $ExposeVirtualizationExtensions
-            $LabVM.IntegrationServices = $IntegrationServices
-            $LabVM.AdministratorPassword = $AdministratorPassword
-            $LabVM.ProductKey = $ProductKey
-            $LabVM.TimeZone =$Timezone
-            $LabVM.UnattendFile = $UnattendFile
-            $LabVM.SetupComplete = $SetupComplete
-            $LabVM.OSType = $OSType
-            $LabVM.CertificateSource = $CertificateSource
-            $LabVM.Bootorder = $Bootorder
-            $LabVM.Packages = $Packages
-            $LabVM.Version = $Version
-            $LabVM.Generation = $Generation
-            $LabVM.Adapters = $VMAdapters
-            $LabVM.DataVHDs = $DataVHDs
-            $LabVM.DVDDrives = $DVDDrives
-            $LabVM.DSC = $LabDSC
-            $LabVM.NanoODJPath = $NanoODJPath
-            $LabVM.VMRootPath = Join-Path `
-                -Path $LabPath `
-                -ChildPath $VMName
-            $LabVM.LabBuilderFilesPath = Join-Path `
-                -Path $LabPath `
-                -ChildPath "$VMName\LabBuilder Files"
-            $LabVMs += @( $LabVM )
+            $labVM = [LabVM]::New($vmName,$computerName)
+            $labVM.Template = $vm.Template
+            $labVM.ParentVHD = $parentVHDPath
+            $labVM.UseDifferencingDisk = $useDifferencingDisk
+            $labVM.MemoryStartupBytes = $memoryStartupBytes
+            $labVM.DynamicMemoryEnabled = $dynamicMemoryEnabled
+            $labVM.ProcessorCount = $processorCount
+            $labVM.ExposeVirtualizationExtensions = $exposeVirtualizationExtensions
+            $labVM.IntegrationServices = $integrationServices
+            $labVM.AdministratorPassword = $administratorPassword
+            $labVM.ProductKey = $productKey
+            $labVM.TimeZone =$timezone
+            $labVM.UnattendFile = $unattendFile
+            $labVM.SetupComplete = $setupComplete
+            $labVM.OSType = $osType
+            $labVM.CertificateSource = $certificateSource
+            $labVM.Bootorder = $bootorder
+            $labVM.Packages = $packages
+            $labVM.Version = $version
+            $labVM.Generation = $generation
+            $labVM.Adapters = $vmAdapters
+            $labVM.DataVHDs = $dataVHDs
+            $labVM.DVDDrives = $dvdDrives
+            $labVM.DSC = $labDSC
+            $labVM.NanoODJPath = $nanoODJPath
+            $labVM.VMRootPath = Join-Path `
+                -Path $labPath `
+                -ChildPath $vmName
+            $labVM.LabBuilderFilesPath = Join-Path `
+                -Path $labPath `
+                -ChildPath "$vmName\LabBuilder Files"
+            $labVMs += @( $labVM )
         } # foreach
     } # foreach
 
-    Return $LabVMs
+    return $labVMs
 } # Get-LabVM

--- a/src/lib/public/Get-LabVmTemplateVhd.ps1
+++ b/src/lib/public/Get-LabVmTemplateVhd.ps1
@@ -237,7 +237,7 @@ function Get-LabVMTemplateVHD
         } # if
 
         # Get the disk size if provided
-        [Int64] $VHDSize = 25GB
+        [System.Int64] $VHDSize = 25GB
         if ($TemplateVHD.VHDSize)
         {
             $VHDSize = (Invoke-Expression $TemplateVHD.VHDSize)

--- a/src/lib/public/Initialize-LabVm.ps1
+++ b/src/lib/public/Initialize-LabVm.ps1
@@ -164,8 +164,10 @@ function Initialize-LabVM
         } # if
 
         # Enable/Disable Dynamic Memory
+        Write-Verbose -Message "Checking Dynamic Memory: $($VM.DynamicMemoryEnabled) = $((Get-VMMemory -VMName $VM.Name).DynamicMemoryEnabled)" -Verbose
         if ($VM.DynamicMemoryEnabled -ne (Get-VMMemory -VMName $VM.Name).DynamicMemoryEnabled)
         {
+            Write-Verbose -Message "Checking Dynamic Memory: $($VM.DynamicMemoryEnabled)" -Verbose
             Set-VMMemory `
                 -VMName $VM.Name `
                 -DynamicMemoryEnabled:$($VM.DynamicMemoryEnabled)

--- a/src/samples/Sample_WS2012R2_DCandDHCPOnly.xml
+++ b/src/samples/Sample_WS2012R2_DCandDHCPOnly.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-DCANDDHCPONLY.COM "
             domainname="LABBUILDER-DCANDDHCPONLY.COM"
             email="admina@LABBUILDER-DCANDDHCPONLY.COM"
-            labpath="c:\vm\LABBUILDER-DCANDDHCPONLY.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCANDDHCPONLY.COM />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
+++ b/src/samples/Sample_WS2012R2_DCandDHCPOnly_NAT.xml
@@ -9,7 +9,6 @@
             domainname="LABBUILDER-NAT.COM"
             email="admina@LABBUILDER-NAT.COM"
             labpath="c:\vm\LABBUILDER-NAT.COM"
-            dsclibrarypath="..\DSCLibrary\"
             requiredwindowsbuild="14295" />
 
   <resources>

--- a/src/samples/Sample_WS2012R2_DCandDHCPandEdge.xml
+++ b/src/samples/Sample_WS2012R2_DCandDHCPandEdge.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-DCDHCPEDGE.COM "
             domainname="LABBUILDER-DCDHCPEDGE.COM"
             email="admina@LABBUILDER-DCDHCPEDGE.COM"
-            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_DomainClustering.xml
+++ b/src/samples/Sample_WS2012R2_DomainClustering.xml
@@ -9,7 +9,6 @@
             domainname="LABBUILDER-DOMAINCLUSTERING.COM"
             email="admin@LABBUILDER-DOMAINCLUSTERING.COM"
             labpath="c:\vm\LABBUILDER-DOMAINCLUSTERING.COM"
-            dsclibrarypath="..\DSCLibrary\"
             requiredwindowsbuild="10586" />
 
   <resources>

--- a/src/samples/Sample_WS2012R2_DomainComplete.xml
+++ b/src/samples/Sample_WS2012R2_DomainComplete.xml
@@ -12,8 +12,7 @@
   <settings labid="LABBUILDER-DOMAINCOMPLETE.COM "
             domainname="LABBUILDER-DOMAINCOMPLETE.COM"
             email="admin@LABBUILDER-DOMAINCOMPLETE.COM"
-            labpath="c:\vm\LABBUILDER-DOMAINCOMPLETE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DOMAINCOMPLETE.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_DomainSQL2014.xml
+++ b/src/samples/Sample_WS2012R2_DomainSQL2014.xml
@@ -20,8 +20,7 @@
   <settings labid="DOMAINSQL2014.COM "
             domainname="DOMAINSQL2014.COM"
             email="admina@DOMAINSQL2014.COM"
-            labpath="c:\vm\DOMAINSQL2014.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\DOMAINSQL2014.COM" />
 
   <resources isopath="ISOFiles">
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_MultiForest.xml
+++ b/src/samples/Sample_WS2012R2_MultiForest.xml
@@ -16,8 +16,7 @@
   <settings labid="LABBUILDER-TWOFORESTS.COM "
             domainname="LABBUILDER-TWOFORESTS.COM"
             email="admina@LABBUILDER-TWOFORESTS.COM"
-            labpath="c:\vm\LABBUILDER-TWOFORESTS.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-TWOFORESTS.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_MultiForest_ADFS.xml
+++ b/src/samples/Sample_WS2012R2_MultiForest_ADFS.xml
@@ -16,8 +16,7 @@
   <settings labid="LABBUILDER-ADFS.COM "
             domainname="LABBUILDER-ADFS.COM"
             email="admina@LABBUILDER-ADFS.COM"
-            labpath="c:\vm\LABBUILDER-ADFS.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-ADFS.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2012R2_Simple.xml
+++ b/src/samples/Sample_WS2012R2_Simple.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-SIMPLE.COM "
             domainname="LABBUILDER-SIMPLE.COM"
             email="admin@LABBUILDER-SIMPLE.COM"
-            labpath="c:\vm\LABBUILDER-SIMPLE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-SIMPLE.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2016_DCandDHCPOnly.xml
+++ b/src/samples/Sample_WS2016_DCandDHCPOnly.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-WS2016.COM "
             domainname="LABBUILDER-WS2016.COM"
             email="admin@LABBUILDER-WS2016.COM"
-            labpath="c:\vm\LABBUILDER-WS2016.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-WS2016.COM" />
 
   <resources>
   </resources>

--- a/src/samples/Sample_WS2016_DCandDHCPandCA.xml
+++ b/src/samples/Sample_WS2016_DCandDHCPandCA.xml
@@ -12,8 +12,7 @@
   <settings labid="LABBUILDER-DCANDDHCPANDCA.COM "
             domainname="LABBUILDER-DCANDDHCPANDCA.COM"
             email="admin@LABBUILDER-DCANDDHCPANDCA.COM"
-            labpath="c:\vm\LABBUILDER-DCANDDHCPANDCA.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCANDDHCPANDCA.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2016_DCandDHCPandEdge.xml
+++ b/src/samples/Sample_WS2016_DCandDHCPandEdge.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-DCDHCPEDGE.COM "
             domainname="LABBUILDER-DCDHCPEDGE.COM"
             email="admina@LABBUILDER-DCDHCPEDGE.COM"
-            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2016_DFSHubAndSpoke.xml
+++ b/src/samples/Sample_WS2016_DFSHubAndSpoke.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-DFSHUBANDSPOKE.COM "
             domainname="LABBUILDER-DFSHUBANDSPOKE.COM"
             email="admina@LABBUILDER-DFSHUBANDSPOKE.COM"
-            labpath="c:\vm\LABBUILDER-DFSHUBANDSPOKE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DFSHUBANDSPOKE.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2016_DomainClustering.xml
+++ b/src/samples/Sample_WS2016_DomainClustering.xml
@@ -9,7 +9,6 @@
             domainname="LABBUILDER-DOMAINCLUSTERING.COM"
             email="admin@LABBUILDER-DOMAINCLUSTERING.COM"
             labpath="c:\vm\LABBUILDER-DOMAINCLUSTERING.COM"
-            dsclibrarypath="..\DSCLibrary\"
             requiredwindowsbuild="10586" />
 
   <switches>

--- a/src/samples/Sample_WS2016_DomainComplete.xml
+++ b/src/samples/Sample_WS2016_DomainComplete.xml
@@ -12,8 +12,7 @@
   <settings labid="LABBUILDER-DOMAINCOMPLETE.COM "
             domainname="LABBUILDER-DOMAINCOMPLETE.COM"
             email="admin@LABBUILDER-DOMAINCOMPLETE.COM"
-            labpath="c:\vm\LABBUILDER-DOMAINCOMPLETE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DOMAINCOMPLETE.COM" />
 
   <resources>
     <msu name="WMF5.1-WS2012R2-W81"

--- a/src/samples/Sample_WS2016_DomainFunctions.xml
+++ b/src/samples/Sample_WS2016_DomainFunctions.xml
@@ -8,8 +8,7 @@
   <settings labid="LBFUNCTIONS.LOCAL "
             domainname="LBFUNCTIONS.LOCAL"
             email="daniel@LBFUNCTIONS.LOCAL"
-            labpath="c:\vm\LBFUNCTIONS.LOCAL"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LBFUNCTIONS.LOCAL" />
 
   <resources isopath="ISOFiles">
     <iso name="SQL2016_Full_ENU"

--- a/src/samples/Sample_WS2016_DomainSQL2016.xml
+++ b/src/samples/Sample_WS2016_DomainSQL2016.xml
@@ -21,8 +21,7 @@
   <settings labid="DOMAINSQL2016.COM "
             domainname="DOMAINSQL2016.COM"
             email="admina@DOMAINSQL2016.COM"
-            labpath="c:\vm\DOMAINSQL2016.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\DOMAINSQL2016.COM" />
 
   <resources isopath="ISOFiles">
     <iso name="SQL2016_Full_ENU"

--- a/src/samples/Sample_WS2016_NanoDomain.xml
+++ b/src/samples/Sample_WS2016_NanoDomain.xml
@@ -8,8 +8,7 @@
   <settings labid="NANOTEST.COM "
             domainname="NANOTEST.COM"
             email="daniel@NANOTEST.COM"
-            labpath="c:\vm\NANOTEST.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\NANOTEST.COM" />
 
   <switches managementvlan="97">
     <switch name="General Purpose External" type="External">

--- a/src/samples/Sample_WS2016_Simple.xml
+++ b/src/samples/Sample_WS2016_Simple.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-SIMPLE.COM "
             domainname="LABBUILDER-SIMPLE.COM"
             email="admin@LABBUILDER-SIMPLE.COM"
-            labpath="c:\vm\LABBUILDER-SIMPLE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-SIMPLE.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2019_AzureADConnect.xml
+++ b/src/samples/Sample_WS2019_AzureADConnect.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-AZUREADCONNECT.COM "
             domainname="LABBUILDER-AZUREADCONNECT.COM"
             email="admina@LABBUILDER-AZUREADCONNECT.COM"
-            labpath="c:\vm\LABBUILDER-AZUREADCONNECT.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-AZUREADCONNECT.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2019_DCandDHCPandCA.xml
+++ b/src/samples/Sample_WS2019_DCandDHCPandCA.xml
@@ -12,8 +12,7 @@
   <settings labid="LABBUILDER-DCANDDHCPANDCA.COM "
             domainname="LABBUILDER-DCANDDHCPANDCA.COM"
             email="admin@LABBUILDER-DCANDDHCPANDCA.COM"
-            labpath="c:\vm\LABBUILDER-DCANDDHCPANDCA.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCANDDHCPANDCA.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2019_DCandDHCPandEdge.xml
+++ b/src/samples/Sample_WS2019_DCandDHCPandEdge.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-DCDHCPEDGE.COM "
             domainname="LABBUILDER-DCDHCPEDGE.COM"
             email="admina@LABBUILDER-DCDHCPEDGE.COM"
-            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-DCDHCPEDGE.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/samples/Sample_WS2019_NanoDomain.xml
+++ b/src/samples/Sample_WS2019_NanoDomain.xml
@@ -8,8 +8,7 @@
   <settings labid="NANOTEST.COM "
             domainname="NANOTEST.COM"
             email="daniel@NANOTEST.COM"
-            labpath="c:\vm\NANOTEST.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\NANOTEST.COM" />
 
   <switches managementvlan="97">
     <switch name="General Purpose External" type="External">

--- a/src/samples/Sample_WS2019_Simple.xml
+++ b/src/samples/Sample_WS2019_Simple.xml
@@ -8,8 +8,7 @@
   <settings labid="LABBUILDER-SIMPLE.COM "
             domainname="LABBUILDER-SIMPLE.COM"
             email="admin@LABBUILDER-SIMPLE.COM"
-            labpath="c:\vm\LABBUILDER-SIMPLE.COM"
-            dsclibrarypath="..\DSCLibrary\" />
+            labpath="c:\vm\LABBUILDER-SIMPLE.COM" />
 
   <switches>
     <switch name="External" type="External">

--- a/src/schema/labbuilderconfig-schema.xsd
+++ b/src/schema/labbuilderconfig-schema.xsd
@@ -71,7 +71,7 @@ The Parent VHD files are used as Parent VHD's to any Lab VM boot disks or cloned
                 <xs:documentation>
 This optional attribute contains the path to the folder that will contain the DSC Library files used by the Virtual Machines in this Lab.
 If this folder is not rooted, it will be assumed to be a subfolder of the 'labpath'.
-If this setting is not set it will default to 'dsclibrary' and will therefore be a subfolder of the 'labpath'.
+If this setting is not set it will default to the 'dsclibrary' folder within this module and will not be a subfolder of the 'labpath'.
 Usually the content of this folder will either be provided with the Lab or created by copying the DSCLibrary folder provided with the LabBuilder module.
 
 Each Virtual Machine that is set to be configured by DSC requires a DSC configuration file that must be found in this folder.

--- a/test/Invoke-LabSample.ps1
+++ b/test/Invoke-LabSample.ps1
@@ -8,7 +8,7 @@ Function Test-StartLabVM {
         [System.String[]]$StartVMs
     )
     $Lab = Get-Lab -Config $Script:ConfigPath
-    [Array]$VMs = Get-LabVM `
+    [array] $VMs = Get-LabVM `
         -Lab $Lab `
         -Name $StartVMs
     Foreach ($VM in $VMs) {

--- a/test/pestertestconfig/PesterTestConfig.OK.xml
+++ b/test/pestertestconfig/PesterTestConfig.OK.xml
@@ -10,7 +10,6 @@
             email="tester@pester.local"
             labpath="C:\Pester Lab"
             vhdparentpath="C:\Pester Lab\Virtual Hard Disk Templates"
-            dsclibrarypath="DSCLibrary"
             resourcepath="Resource"
             modulepath="Modules"
             dismpath="C:\dism"
@@ -240,7 +239,7 @@
         </adapter>
       </adapters>
       <dsc configname="STANDALONE_DEFAULT"
-           configfile="PesterTest.DSC.ps1"
+           configfile="STANDALONE_DEFAULT.DSC.PS1"
            logging="Y">
         <parameters>
           Dummy = "Dummy"

--- a/test/unit/lib/private/ManagementSwitch.tests.ps1
+++ b/test/unit/lib/private/ManagementSwitch.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/private/dsc.tests.ps1
+++ b/test/unit/lib/private/dsc.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/private/utils.tests.ps1
+++ b/test/unit/lib/private/utils.tests.ps1
@@ -33,7 +33,7 @@ InModuleScope LabBuilder {
         -Force `
         -ErrorAction SilentlyContinue
 
-    Describe '\lib\private\Utils.ps1\Invoke-LabDownloadAndUnzipFile' {
+    Describe '\lib\private\Invoke-LabDownloadAndUnzipFile.ps1' {
         $URL = 'https://raw.githubusercontent.com/PlagueHO/LabBuilder/dev/LICENSE'
 
         Context 'When Download folder does not exist' {
@@ -143,7 +143,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Invoke-LabDownloadResourceModule' {
+    Describe '\lib\private\Invoke-LabDownloadResourceModule.ps1' {
         $URL = 'https://github.com/PowerShell/NetworkingDsc/archive/dev.zip'
 
         Mock -CommandName Get-Module -MockWith { @( New-Object -TypeName PSObject -Property @{ Name = 'NetworkingDsc'; Version = '2.4.0.0'; } ) }
@@ -528,7 +528,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\New-LabCredential' {
+    Describe '\lib\private\New-LabCredential.ps1' {
         Context 'When Username and Password provided' {
             $testUsername = 'testUsername'
             $testPassword = 'testPassword'
@@ -544,7 +544,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Install-LabHyperV' {
+    Describe '\lib\private\Install-LabHyperV.ps1' {
         $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
 
         if ((Get-CimInstance Win32_OperatingSystem).ProductType -eq 1) {
@@ -587,7 +587,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Enable-LabWSMan' {
+    Describe '\lib\private\Enable-LabWSMan.ps1' {
         Context 'When WS-Man is already enabled' {
             Mock -CommandName Start-Service
             Mock -CommandName Get-PSProvider -MockWith {
@@ -628,10 +628,10 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Assert-LabValidConfigurationXMLSchema' -Tag 'Incomplete' {
+    Describe '\lib\private\Assert-LabValidConfigurationXMLSchema.ps1' -Tag 'Incomplete' {
     }
 
-    Describe '\lib\private\Utils.ps1\Get-NextMacAddress' {
+    Describe '\lib\private\Get-NextMacAddress.ps1' {
         Context 'When MAC address 00155D0106ED is passed' {
             It 'Returns MAC address 00155D0106EE' {
                 Get-NextMacAddress `
@@ -656,7 +656,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Get-LabNextIpAddress' {
+    Describe '\lib\private\Get-LabNextIpAddress.ps1' {
         Context 'When Invalid IP Address is passed' {
             It 'Throws a IPAddressError Exception' {
                 $exceptionParameters = @{
@@ -719,7 +719,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Assert-LabValidIpAddress' {
+    Describe '\lib\private\Assert-LabValidIpAddress.ps1' {
         Context 'When IP address 192.168.1.1 is passed' {
             It 'Returns IP Address' {
                 Assert-LabValidIpAddress `
@@ -753,7 +753,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Install-LabPackageProvider' {
+    Describe '\lib\private\Install-LabPackageProvider.ps1' {
         Context 'When Required package providers already installed' {
             Mock -CommandName Get-PackageProvider -MockWith {
                 @(
@@ -791,7 +791,7 @@ InModuleScope LabBuilder {
 
 
 
-    Describe '\lib\private\Utils.ps1\Register-LabPackageSource' {
+    Describe '\lib\private\Register-LabPackageSource.ps1' {
         # Define this function because the built in definition does not
         # Mock -CommandName properly - the ProviderName parameter is not definied.
         function Register-PackageSource
@@ -899,7 +899,7 @@ InModuleScope LabBuilder {
         }
     }
 
-    Describe '\lib\private\Utils.ps1\Write-LabMessage' {
+    Describe '\lib\private\Write-LabMessage.ps1' {
         $script:testMessage = 'Test Message'
         $script:testMessageTime = Get-Date -UFormat %T
         $script:testMessageWithTime = ('[{0}]: {1}' -f $script:testMessageTime, $script:testMessage)
@@ -989,6 +989,26 @@ InModuleScope LabBuilder {
             It 'Calls appropriate mocks' {
                 Assert-MockCalled -CommandName Write-Host -ParameterFilter { $Object -eq $script:testMessage } -Exactly -Times 1
             }
+        }
+    }
+
+    Describe '\lib\private\ConvertTo-LabAbsolutePath.ps1' {
+        Context 'When absolute Path is passed' {
+            It 'Should return the absolute path' {
+                ConvertTo-LabAbsolutePath -Path 'c:\absolutepath' -BasePath 'c:\mylab' | Should -BeExactly 'c:\absolutepath'
+            }
+        }
+
+        Context 'When relative Path is passed' {
+            It 'Should return the absolute path' {
+                ConvertTo-LabAbsolutePath -Path 'relativepath' -BasePath 'c:\mylab' | Should -BeExactly 'c:\mylab\relativepath'
+            }
+        }
+    }
+
+    Describe '\lib\private\Get-LabBuilderModulePath.ps1' {
+        It 'Should return the path to the LabBuilder Module' {
+            Get-LabBuilderModulePath | Should -BeExactly (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src')
         }
     }
 }

--- a/test/unit/lib/private/utils.tests.ps1
+++ b/test/unit/lib/private/utils.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/private/vhd.tests.ps1
+++ b/test/unit/lib/private/vhd.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/private/vm.tests.ps1
+++ b/test/unit/lib/private/vm.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 
@@ -143,11 +144,11 @@ InModuleScope LabBuilder {
         Mock -CommandName Disable-VMIntegrationService
 
         $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-        [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-        [Array]$Switches = Get-LabSwitch -Lab $Lab
+        [array] $Templates = Get-LabVMTemplate -Lab $Lab
+        [array] $Switches = Get-LabSwitch -Lab $Lab
 
         Context 'When valid configuration is passed with null Integration Services' {
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
             $VMs[0].IntegrationServices = $null
 
             It 'Does not throw an Exception' {
@@ -162,7 +163,7 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with blank Integration Services' {
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
             $VMs[0].IntegrationServices = ''
 
             It 'Does not throw an Exception' {
@@ -177,7 +178,7 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with VSS only enabled' {
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
             $VMs[0].IntegrationServices = 'VSS'
 
             It 'Does not throw an Exception' {
@@ -192,7 +193,7 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with Guest Service Interface only enabled' {
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
             $VMs[0].IntegrationServices = 'Guest Service Interface'
 
             It 'Does not throw an Exception' {
@@ -237,9 +238,9 @@ InModuleScope LabBuilder {
         # The same VM will be used for all tests, but a different
         # DataVHds array will be created/assigned for each test.
         $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-        [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-        [Array]$Switches = Get-LabSwitch -Lab $Lab
-        [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+        [array] $Templates = Get-LabVMTemplate -Lab $Lab
+        [array] $Switches = Get-LabSwitch -Lab $Lab
+        [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
 
         Context 'When valid configuration is passed with no DataVHDs' {
             $VMs[0].DataVHDs = @()
@@ -711,9 +712,9 @@ InModuleScope LabBuilder {
         # The same VM will be used for all tests, but a different
         # DVD Drives array will be created/assigned for each test.
         $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-        [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-        [Array]$Switches = Get-LabSwitch -Lab $Lab
-        [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+        [array] $Templates = Get-LabVMTemplate -Lab $Lab
+        [array] $Switches = Get-LabSwitch -Lab $Lab
+        [array] $VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
 
         Context 'When valid configuration is passed with no DVDDrives' {
             $VMs[0].DVDDrives = @()

--- a/test/unit/lib/public/lab.tests.ps1
+++ b/test/unit/lib/public/lab.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/public/resource.tests.ps1
+++ b/test/unit/lib/public/resource.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/public/switch.tests.ps1
+++ b/test/unit/lib/public/switch.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/public/templatevhd.tests.ps1
+++ b/test/unit/lib/public/templatevhd.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/public/templatevhd.tests.ps1
+++ b/test/unit/lib/public/templatevhd.tests.ps1
@@ -309,7 +309,7 @@ InModuleScope LabBuilder {
         # Mock Convert-WindowsImage
         if (-not (Test-Path -Path Function:Convert-WindowsImage))
         {
-            . (Join-Path -Path $script:ModuleRoot -ChildPath 'support\Convert-WindowsImage.ps1')
+            . (Join-Path -Path $script:LabBuidlerModuleRoot -ChildPath 'support\Convert-WindowsImage.ps1')
         }
         Mock Convert-WindowsImage
         Mock Resolve-Path -MockWith { 'X:\Sources\Install.WIM' }

--- a/test/unit/lib/public/vm.tests.ps1
+++ b/test/unit/lib/public/vm.tests.ps1
@@ -554,7 +554,7 @@ InModuleScope LabBuilder {
                 $lab.labbuilderconfig.vms.vm.dsc.configfile = 'ThisFileDoesntExist.ps1'
                 [array] $Switches = Get-LabSwitch -Lab $lab
                 [array] $Templates = Get-LabVMTemplate -Lab $lab
-                $expectedPath = Split-Path -Path $script:LabBuidlerModuleRoot -Parent |
+                $expectedPath = Split-Path -Path (Join-Path -Path $script:LabBuidlerModuleRoot -ChildPath 'src') -Parent |
                     Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileMissingError'
@@ -572,7 +572,7 @@ InModuleScope LabBuilder {
                 $lab.labbuilderconfig.vms.vm.dsc.configfile = 'FileWithBadType.xyz'
                 [array] $Switches = Get-LabSwitch -Lab $lab
                 [array] $Templates = Get-LabVMTemplate -Lab $lab
-                $expectedPath = Split-Path -Path $script:LabBuidlerModuleRoot -Parent |
+                $expectedPath = Split-Path -Path (Join-Path -Path $script:LabBuidlerModuleRoot -ChildPath 'src') -Parent |
                     Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileBadTypeError'

--- a/test/unit/lib/public/vm.tests.ps1
+++ b/test/unit/lib/public/vm.tests.ps1
@@ -7,7 +7,8 @@ if (Get-Module -Name LabBuilder -All)
 
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'src\LabBuilder.psd1') `
     -Force `
-    -DisableNameChecking
+    -DisableNameChecking `
+    -Verbose:$false
 Import-Module -Name (Join-Path -Path $global:LabBuilderProjectRoot -ChildPath 'test\testhelper\testhelper.psm1') `
     -Global
 

--- a/test/unit/lib/public/vm.tests.ps1
+++ b/test/unit/lib/public/vm.tests.ps1
@@ -45,372 +45,372 @@ InModuleScope LabBuilder {
         $Script:CurrentBuild = 10586
 
         # Figure out the TestVMName (saves typing later on)
-        $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-        $TestVMName = "$($Lab.labbuilderconfig.settings.labid)$($Lab.labbuilderconfig.vms.vm.name)"
+        $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+        $TestVMName = "$($lab.labbuilderconfig.settings.labid)$($lab.labbuilderconfig.vms.vm.name)"
 
         Context 'When valid configuration passed with VM missing VM Name' {
             It 'Throw VMNameError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.RemoveAttribute('name')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.RemoveAttribute('name')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMNameError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMNameError)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM missing Template' {
             It 'Throw VMTemplateNameEmptyError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.RemoveAttribute('template')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.RemoveAttribute('template')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMTemplateNameEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNameEmptyError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM invalid Template Name' {
             It 'Throw VMTemplateNotFoundError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.template = 'BadTemplate'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.template = 'BadTemplate'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMTemplateNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMTemplateNotFoundError `
                         -f $TestVMName,'BadTemplate')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM missing adapter name' {
             It 'Throw VMAdapterNameError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.adapters.adapter[0].RemoveAttribute('name')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.adapters.adapter[0].RemoveAttribute('name')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMAdapterNameError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMAdapterNameError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM missing adapter switch name' {
             It 'Throw VMAdapterSwitchNameError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.adapters.adapter[0].RemoveAttribute('switchname')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.adapters.adapter[0].RemoveAttribute('switchname')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMAdapterSwitchNameError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMAdapterSwitchNameError `
-                        -f $TestVMName,$($Lab.labbuilderconfig.vms.vm.adapters.adapter[0].name))
+                        -f $TestVMName,$($lab.labbuilderconfig.vms.vm.adapters.adapter[0].name))
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk with empty VHD' {
             It 'Throw VMDataDiskVHDEmptyError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = ''
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = ''
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskVHDEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskVHDEmptyError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk where ParentVHD can not be found' {
             It 'Throw VMDataDiskParentVHDNotFoundError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = 'c:\ThisFileDoesntExist.vhdx'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = 'c:\ThisFileDoesntExist.vhdx'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskParentVHDNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskParentVHDNotFoundError `
                         -f $TestVMName,"c:\ThisFileDoesntExist.vhdx")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk where SourceVHD can not be found' {
             It 'Throw VMDataDiskSourceVHDNotFoundError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = 'c:\ThisFileDoesntExist.vhdx'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = 'c:\ThisFileDoesntExist.vhdx'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskSourceVHDNotFoundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSourceVHDNotFoundError `
                         -f $TestVMName,"c:\ThisFileDoesntExist.vhdx")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Differencing Data Disk with empty ParentVHD' {
             It 'Throw VMDataDiskParentVHDMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].RemoveAttribute('parentvhd')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].RemoveAttribute('parentvhd')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskParentVHDMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskParentVHDMissingError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk where it is a Differencing type disk but is shared' {
             It 'Throw VMDataDiskSharedDifferencingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].SetAttribute('Shared','Y')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].SetAttribute('Shared','Y')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskSharedDifferencingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSharedDifferencingError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk where it has an unknown Type' {
             It 'Throw VMDataDiskUnknownTypeError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].type = 'badtype'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].type = 'badtype'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskUnknownTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskUnknownTypeError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'badtype')
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'badtype')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that has an invalid Partition Style' {
             It 'Throw VMDataDiskPartitionStyleError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].PartitionStyle='Bad'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].PartitionStyle='Bad'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskPartitionStyleError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that has an invalid File System' {
             It 'Throw VMDataDiskFileSystemError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].FileSystem='Bad'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].FileSystem='Bad'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskFileSystemError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskFileSystemError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)",'Bad')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that has a File System set but not a Partition Style' {
             It 'Throw VMDataDiskPartitionStyleMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('partitionstyle')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('partitionstyle')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskPartitionStyleMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleMissingError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that has a Partition Style set but not a File System' {
             It 'Throw VMDataDiskFileSystemMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('filesystem')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('filesystem')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskFileSystemMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskFileSystemMissingError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that has a File System Label set but not a Partition Style or File System' {
             It 'Throw VMDataDiskPartitionStyleMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].RemoveAttribute('partitionstyle')
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].RemoveAttribute('filesystem')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].RemoveAttribute('partitionstyle')
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].RemoveAttribute('filesystem')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskPartitionStyleMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskPartitionStyleMissingError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[2].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that exists with CopyFolders set to a folder that does not exist' {
             It 'Throw VMDataDiskCopyFolderMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].CopyFolders='c:\doesnotexist'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].CopyFolders='c:\doesnotexist'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskCopyFolderMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCopyFolderMissingError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)",'c:\doesnotexist')
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)",'c:\doesnotexist')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that does not exist but Type missing' {
             It 'Throw VMDataDiskCantBeCreatedError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('type')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('type')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that does not exist but Size missing' {
             It 'Throw VMDataDiskCantBeCreatedError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('size')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].RemoveAttribute('size')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[1].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration passed with VM Data Disk that does not exist but SourceVHD missing' {
             It 'Throw VMDataDiskCantBeCreatedError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].RemoveAttribute('sourcevhd')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].RemoveAttribute('sourcevhd')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskCantBeCreatedError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskCantBeCreatedError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context "Configuration passed with VM Data Disk that has MoveSourceVHD flag but SourceVHD missing." {
             It 'Throw VMDataDiskSourceVHDIfMoveError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[4].RemoveAttribute('sourcevhd')
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.datavhds.datavhd[4].RemoveAttribute('sourcevhd')
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDataDiskSourceVHDIfMoveError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDataDiskSourceVHDIfMoveError `
-                        -f $TestVMName,"$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($Lab.labbuilderconfig.vms.vm.datavhds.datavhd[4].vhd)")
+                        -f $TestVMName,"$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\$($lab.labbuilderconfig.vms.vm.datavhds.datavhd[4].vhd)")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration is passed with VM Data Disk with rooted VHD path.' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing VHD with correct rooted path' {
                 $VMs[0].DataVhds[0].vhd | Should -Be "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
@@ -418,23 +418,23 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with VM Data Disk with non-rooted VHD path.' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = "DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].vhd = "DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing VHD with correct rooted path' {
-                $VMs[0].DataVhds[0].vhd | Should -Be "$($Lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\DataDisk.vhdx"
+                $VMs[0].DataVhds[0].vhd | Should -Be "$($lab.labbuilderconfig.settings.labpath)\$TestVMName\Virtual Hard Disks\DataDisk.vhdx"
             }
         }
 
         Context 'When valid configuration is passed with VM Data Disk with rooted Parent VHD path.' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing Parent VHD with correct rooted path' {
                 $VMs[0].DataVhds[3].parentvhd | Should -Be "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
@@ -443,11 +443,11 @@ InModuleScope LabBuilder {
 
         Context 'When valid configuration is passed with VM Data Disk with non-rooted Parent VHD path.' {
             Mock Test-Path -MockWith { $true }
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = "VhdFiles\DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[3].parentvhd = "VhdFiles\DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing Parent VHD with correct rooted path' {
                 $VMs[0].DataVhds[3].parentvhd | Should -Be "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
@@ -455,11 +455,11 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with VM Data Disk with rooted Source VHD path.' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing Source VHD with correct rooted path' {
                 $VMs[0].DataVhds[0].sourcevhd | Should -Be "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
@@ -468,181 +468,183 @@ InModuleScope LabBuilder {
 
         Context 'When valid configuration is passed with VM Data Disk with non-rooted Source VHD path.' {
             Mock Test-Path -MockWith { $true }
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $Lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = "VhdFiles\DataDisk.vhdx"
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab.labbuilderconfig.vms.vm.datavhds.datavhd[0].sourcevhd = "VhdFiles\DataDisk.vhdx"
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns Template Object containing Source VHD with correct rooted path' {
                 $VMs[0].DataVhds[0].sourcevhd | Should -Be "$script:TestConfigPath\VhdFiles\DataDisk.vhdx"
             }
         }
 
-        Context "Configuration passed with VM DVD Drive that has a missing Resource ISO." {
+        Context 'When the configuration passed with VM DVD Drive that has a missing Resource ISO' {
             It 'Throw VMDataDiskSourceVHDIfMoveError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.dvddrives.dvddrive[0].iso='DoesNotExist'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.dvddrives.dvddrive[0].iso='DoesNotExist'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMDVDDriveISOResourceNotFOundError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMDVDDriveISOResourceNotFOundError `
                         -f $TestVMName,'DoesNotExist')
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context "Configuration passed with VM unattend file that can't be found." {
+        Context 'When the configuration passed with VM unattend file that can not be found' {
             It 'Throw UnattendFileMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.unattendfile = 'ThisFileDoesntExist.xml'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.unattendfile = 'ThisFileDoesntExist.xml'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'UnattendFileMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.UnattendFileMissingError `
                         -f $TestVMName,"$script:TestConfigPath\ThisFileDoesntExist.xml")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context "Configuration passed with VM setup complete file that can't be found." {
+        Context 'When the configuration passed with VM setup complete file that can not be found' {
             It 'Throw SetupCompleteFileMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.setupcomplete = 'ThisFileDoesntExist.ps1'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.setupcomplete = 'ThisFileDoesntExist.ps1'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'SetupCompleteFileMissingError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.SetupCompleteFileMissingError `
                         -f $TestVMName,"$script:TestConfigPath\ThisFileDoesntExist.ps1")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context 'Configuration passed with VM setup complete file with an invalid file extension.' {
+        Context 'When the configuration passed with VM setup complete file with an invalid file extension' {
             It 'Throw SetupCompleteFileBadTypeError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.setupcomplete = 'ThisFileDoesntExist.abc'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.setupcomplete = 'ThisFileDoesntExist.abc'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'SetupCompleteFileBadTypeError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.SetupCompleteFileBadTypeError `
                         -f $TestVMName,"$script:TestConfigPath\ThisFileDoesntExist.abc")
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context "Configuration passed with VM DSC Config File that can't be found." {
+        Context 'When the configuration passed with VM DSC Config File that can not be found' {
             It 'Throw DSCConfigFileMissingError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.dsc.configfile = 'ThisFileDoesntExist.ps1'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.dsc.configfile = 'ThisFileDoesntExist.ps1'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
+                $expectedPath = Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent |
+                    Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileMissingError'
                     errorCategory = 'InvalidArgument'
-                    errorMessage = $($LocalizedData.DSCConfigFileMissingError `
-                        -f $TestVMName,"$script:TestConfigPath\DSCLibrary\ThisFileDoesntExist.ps1")
+                    errorMessage = $($LocalizedData.DSCConfigFileMissingError -f $TestVMName, $expectedPath)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context 'Configuration passed with VM DSC Config File with an invalid file extension.' {
+        Context 'When the configuration passed with VM DSC Config File with an invalid file extension' {
             It 'Throw DSCConfigFileBadTypeError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.dsc.configfile = 'FileWithBadType.xyz'
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.dsc.configfile = 'FileWithBadType.xyz'
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
+                $expectedPath = Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent |
+                    Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileBadTypeError'
                     errorCategory = 'InvalidArgument'
-                    errorMessage = $($LocalizedData.DSCConfigFileBadTypeError `
-                        -f $TestVMName,"$script:TestConfigPath\DSCLibrary\FileWithBadType.xyz")
+                    errorMessage = $($LocalizedData.DSCConfigFileBadTypeError -f $TestVMName, $expectedPath)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
-        Context 'Configuration passed with VM DSC Config File but no DSC Name.' {
+        Context 'When the configuration passed with VM DSC Config File but no DSC Name' {
             It 'Throw DSCConfigNameIsEmptyError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                $Lab.labbuilderconfig.vms.vm.dsc.configname = ''
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                $lab.labbuilderconfig.vms.vm.dsc.configname = ''
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'DSCConfigNameIsEmptyError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.DSCConfigNameIsEmptyError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         Context 'When valid configuration is passed with and Name filter set to matching switch' {
             It 'Returns a Single Switch object' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-                [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches -Name $Lab.labbuilderconfig.VMs.VM.Name
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
+                [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches -Name $lab.labbuilderconfig.VMs.VM.Name
                 $VMs.Count | Should -Be 1
             }
         }
 
         Context 'When valid configuration is passed with and Name filter set to non-matching switch' {
             It 'Returns a Single Switch object' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-                [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches -Name 'Does Not Exist'
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
+                [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches -Name 'Does Not Exist'
                 $VMs.Count | Should -Be 0
             }
         }
 
         $Script:CurrentBuild = 10560
 
-        Context 'Configuration passed with ExposeVirtualizationExtensions required but Build is 10560.' {
+        Context 'When the configuration passed with ExposeVirtualizationExtensions required but Build is 10560' {
             It 'Throw DSCConfigNameIsEmptyError Exception' {
-                $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                [Array]$Switches = Get-LabSwitch -Lab $Lab
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+                $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+                [array] $Switches = Get-LabSwitch -Lab $lab
+                [array] $Templates = Get-LabVMTemplate -Lab $lab
                 $exceptionParameters = @{
                     errorId = 'VMVirtualizationExtError'
                     errorCategory = 'InvalidArgument'
                     errorMessage = $($LocalizedData.VMVirtualizationExtError `
                         -f $TestVMName)
                 }
-                $Exception = Get-LabException @exceptionParameters
-                { Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $Exception
+                $exception = Get-LabException @exceptionParameters
+                { Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches } | Should -Throw $exception
             }
         }
 
         $Script:CurrentBuild = 10586
 
         Context 'When valid configuration is passed but switches and VMTemplates not passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
             # Set the Instance Count to 2 to check
-            $Lab.labbuilderconfig.vms.vm.instancecount = '2'
-            [Array]$VMs = Get-LabVM -Lab $Lab
+            $lab.labbuilderconfig.vms.vm.instancecount = '2'
+            [array] $VMs = Get-LabVM -Lab $lab
             # Remove the Source VHD and Parent VHD values for any data disks because they
             # will usually be relative to the test folder and won't exist
             foreach ($VM in $VMs)
@@ -664,12 +666,12 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
             # Set the Instance Count to 2 to check
-            $Lab.labbuilderconfig.vms.vm.instancecount = '2'
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab.labbuilderconfig.vms.vm.instancecount = '2'
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
             # Remove the Source VHD and Parent VHD values for any data disks because they
             # will usually be relative to the test folder and won't exist
             foreach ($VM in $VMs)
@@ -709,16 +711,16 @@ InModuleScope LabBuilder {
         #endregion
 
         Context 'When valid configuration is passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $null = New-Item -Path $Lab.labbuilderconfig.settings.labpath -ItemType Directory -Force -ErrorAction SilentlyContinue
-            $null = New-Item -Path $Lab.labbuilderconfig.settings.vhdparentpath -ItemType Directory -Force -ErrorAction SilentlyContinue
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $null = New-Item -Path $lab.labbuilderconfig.settings.labpath -ItemType Directory -Force -ErrorAction SilentlyContinue
+            $null = New-Item -Path $lab.labbuilderconfig.settings.vhdparentpath -ItemType Directory -Force -ErrorAction SilentlyContinue
 
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns True' {
-                Initialize-LabVM -Lab $Lab -VMs $VMs | Should -Be $true
+                Initialize-LabVM -Lab $lab -VMs $VMs | Should -Be $true
             }
 
             It 'Calls Mocked commands' {
@@ -736,8 +738,8 @@ InModuleScope LabBuilder {
                 Assert-MockCalled Install-LabVMDSC -Exactly 1
             }
 
-            Remove-Item -Path $Lab.labbuilderconfig.settings.labpath -Recurse -Force -ErrorAction SilentlyContinue
-            Remove-Item -Path $Lab.labbuilderconfig.settings.vhdparentpath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $lab.labbuilderconfig.settings.labpath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $lab.labbuilderconfig.settings.vhdparentpath -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 
@@ -757,14 +759,14 @@ InModuleScope LabBuilder {
         #endregion
 
         Context 'When valid configuration is passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             # Create the dummy VM's that the Remove-LabVM function
             It 'Returns True' {
-                Remove-LabVM -Lab $Lab -VMs $VMs | Should -Be $true
+                Remove-LabVM -Lab $lab -VMs $VMs | Should -Be $true
             }
 
             It 'Calls Mocked commands' {
@@ -777,11 +779,11 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed but VMs not passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
 
             # Create the dummy VM's that the Remove-LabVM function
             It 'Returns True' {
-                Remove-LabVM -Lab $Lab | Should -Be $true
+                Remove-LabVM -Lab $lab | Should -Be $true
             }
 
             It 'Calls Mocked commands' {
@@ -794,14 +796,14 @@ InModuleScope LabBuilder {
         }
 
         Context 'When valid configuration is passed with RemoveVHDs switch' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             # Create the dummy VM's that the Remove-LabVM function
             It 'Returns True' {
-                Remove-LabVM -Lab $Lab -VMs $VMs -RemoveVMFolder | Should -Be $true
+                Remove-LabVM -Lab $lab -VMs $VMs -RemoveVMFolder | Should -Be $true
             }
 
             It 'Calls Mocked commands' {
@@ -826,16 +828,16 @@ InModuleScope LabBuilder {
         #endregion
 
         Context 'When valid configuration is passed' {
-            $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-            $null = New-Item -Path $Lab.labbuilderconfig.settings.labpath -ItemType Directory -Force -ErrorAction SilentlyContinue
-            $null = New-Item -Path $Lab.labbuilderconfig.settings.vhdparentpath -ItemType Directory -Force -ErrorAction SilentlyContinue
+            $lab = Get-Lab -ConfigPath $script:TestConfigOKPath
+            $null = New-Item -Path $lab.labbuilderconfig.settings.labpath -ItemType Directory -Force -ErrorAction SilentlyContinue
+            $null = New-Item -Path $lab.labbuilderconfig.settings.vhdparentpath -ItemType Directory -Force -ErrorAction SilentlyContinue
 
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
-            [Array]$Switches = Get-LabSwitch -Lab $Lab
-            [Array]$VMs = Get-LabVM -Lab $Lab -VMTemplates $Templates -Switches $Switches
+            [array] $Templates = Get-LabVMTemplate -Lab $lab
+            [array] $Switches = Get-LabSwitch -Lab $lab
+            [array] $VMs = Get-LabVM -Lab $lab -VMTemplates $Templates -Switches $Switches
 
             It 'Returns True' {
-                Install-LabVM -Lab $Lab -VM $VMs[0] | Should -Be $true
+                Install-LabVM -Lab $lab -VM $VMs[0] | Should -Be $true
             }
 
             It 'Calls Mocked commands' {
@@ -848,8 +850,8 @@ InModuleScope LabBuilder {
                 Assert-MockCalled Install-LabVMDSC -Exactly 1
             }
 
-            Remove-Item -Path $Lab.labbuilderconfig.settings.labpath -Recurse -Force -ErrorAction SilentlyContinue
-            Remove-Item -Path $Lab.labbuilderconfig.settings.vhdparentpath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $lab.labbuilderconfig.settings.labpath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $lab.labbuilderconfig.settings.vhdparentpath -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 

--- a/test/unit/lib/public/vm.tests.ps1
+++ b/test/unit/lib/public/vm.tests.ps1
@@ -554,7 +554,7 @@ InModuleScope LabBuilder {
                 $lab.labbuilderconfig.vms.vm.dsc.configfile = 'ThisFileDoesntExist.ps1'
                 [array] $Switches = Get-LabSwitch -Lab $lab
                 [array] $Templates = Get-LabVMTemplate -Lab $lab
-                $expectedPath = Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent |
+                $expectedPath = Split-Path -Path $script:LabBuidlerModuleRoot -Parent |
                     Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileMissingError'
@@ -572,7 +572,7 @@ InModuleScope LabBuilder {
                 $lab.labbuilderconfig.vms.vm.dsc.configfile = 'FileWithBadType.xyz'
                 [array] $Switches = Get-LabSwitch -Lab $lab
                 [array] $Templates = Get-LabVMTemplate -Lab $lab
-                $expectedPath = Split-Path -Path ((Get-Module -Name LabBuilder).Path) -Parent |
+                $expectedPath = Split-Path -Path $script:LabBuidlerModuleRoot -Parent |
                     Join-Path -ChildPath 'DSCLibrary' | Join-Path -ChildPath $lab.labbuilderconfig.vms.vm.dsc.configfile
                 $exceptionParameters = @{
                     errorId = 'DSCConfigFileBadTypeError'

--- a/test/unit/lib/public/vmtemplate.tests.ps1
+++ b/test/unit/lib/public/vmtemplate.tests.ps1
@@ -138,7 +138,7 @@ InModuleScope LabBuilder {
         Context 'When valid configuration is passed but no templates found' {
             It 'Returns Template Object that matches Expected Object' {
                 $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+                [array] $Templates = Get-LabVMTemplate -Lab $Lab
                 # Remove the SourceVHD values for any templates because they
                 # will usually be relative to the test folder and won't exist
                 foreach ($Template in $Templates)
@@ -193,7 +193,7 @@ InModuleScope LabBuilder {
             It 'Returns Template Object that matches Expected Object' {
                 $Lab = Get-Lab -ConfigPath $script:TestConfigOKPath
                 $Lab.labbuilderconfig.templates.SetAttribute('fromvm','Pester *')
-                [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+                [array] $Templates = Get-LabVMTemplate -Lab $Lab
                 # Remove the SourceVHD values for any templates because they
                 # will usually be relative to the test folder and won't exist
                 foreach ($Template in $Templates)
@@ -324,7 +324,7 @@ InModuleScope LabBuilder {
         Mock Get-VM
 
         Context 'When Valid configuration is passed' {
-            [Array]$Templates = Get-LabVMTemplate -Lab $Lab
+            [array] $Templates = Get-LabVMTemplate -Lab $Lab
 
             It 'Does not throw an Exception' {
                 { Remove-LabVMTemplate -Lab $Lab -VMTemplates $Templates } | Should -Not -Throw


### PR DESCRIPTION
- `Get-LabVm.ps1`:
  - Clean up code style.
- `Enable-LabWSMan.ps1`:
  - Improved function so that if WinRM Service is stopped it will be started.
- `Get-Lab.ps1`:
  - Clean up code style.
  - Fix bug reading `configpath` from `settings` node.
  - Changed to use `ConvertTo-LabAbsolutePath.ps1` to simplify code.
  - Changed to automatically use the `DSCLibrary` folder that comes as part of
    the LabBuilder module if the `dsclibrarypath` setting is not specified
    in the lab configuration - fixes [Issue-335](https://github.com/PlagueHO/LabBuilder/issues/335).
- `ConvertTo-LabAbsolutePath.ps1`:
  - Added function to create an absolute path from a relative lab path.
- Removed `dsclibrarypath` setting from all samples as it is no longer required.
- `Get-LabResourceISO.ps1`:
  - Clean up code style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/341)
<!-- Reviewable:end -->
