### PR TITLE
Adding Windows 7/Server 2008 Support

### DIFF
--- a/docs/about_LabBuilderSchema.md
+++ b/docs/about_LabBuilderSchema.md
@@ -720,7 +720,7 @@ This optional attribute controls the Virtual Machine generation to create.
 This optional attribute controls the Virtual Machine Version to create, this is only applicable to Windows 10 build 14352 or higher/Server 2016 post TP5.
 
 - Default Value: 8.0
-- Valid Values: 5.0, 6.2, 7.0, 7.1, 8.0, 254.0, and 255.0
+- Valid Values: 5.0, 6.2, 7.0, 7.1, 8.0, 9.0, 254.0, and 255.0
 
 ```version="5.0"```
 

--- a/src/LabBuilder.psm1
+++ b/src/LabBuilder.psm1
@@ -329,7 +329,7 @@ class LabVMTemplate:System.ICloneable {
     [System.String[]] $IntegrationServices = @('Guest Service Interface','Heartbeat','Key-Value Pair Exchange','Shutdown','Time Synchronization','VSS')
     [System.String[]] $Packages
     [ValidateRange(1,2)][Byte] $Generation = 2
-    [ValidateSet("5.0","6.2","7.0","7.1","8.0","254.0","255.0")][System.String] $Version = '8.0'
+    [ValidateSet("5.0","6.2","7.0","7.1","8.0","9.0","254.0","255.0")][System.String] $Version = '8.0'
 
     LabVMTemplate() {}
 
@@ -423,7 +423,7 @@ class LabVM:System.ICloneable {
     [System.String] $SetupComplete
     [System.String[]] $Packages
     [ValidateRange(1,2)][Byte] $Generation = 2
-    [ValidateSet("5.0","6.2","7.0","7.1","8.0","254.0","255.0")][System.String] $Version = '8.0'
+    [ValidateSet("5.0","6.2","7.0","7.1","8.0","9.0","254.0","255.0")][System.String] $Version = '8.0'
     [System.Int32] $BootOrder
     [System.String[]] $IntegrationServices = @('Guest Service Interface','Heartbeat','Key-Value Pair Exchange','Shutdown','Time Synchronization','VSS')
     [LabVMAdapter[]] $Adapters

--- a/src/lib/private/Get-LabCertificatePsFileContent.ps1
+++ b/src/lib/private/Get-LabCertificatePsFileContent.ps1
@@ -80,10 +80,19 @@ if (-not `$Cert)
             | Where-Object { `$_.FriendlyName -eq `$CertificateFriendlyName }
     }
 }
-Export-Certificate ``
-    -Type CERT ``
-    -Cert `$Cert ``
-    -FilePath `"`$(`$ENV:SystemRoot)\$Script:DSCEncryptionCert`"
+if ((Get-WmiObject -Class Win32_OperatingSystem).Version -eq '6.1.7601') {
+    `$content = @(
+        '-----BEGIN CERTIFICATE-----'
+        [System.Convert]::ToBase64String(`$cert.RawData, 'InsertLineBreaks')
+        '-----END CERTIFICATE-----'
+    )
+    `$content | Out-File -FilePath `"`$(`$ENV:SystemRoot)\$Script:DSCEncryptionCert`" -Encoding ascii
+} else {
+    Export-Certificate ``
+        -Type CERT ``
+        -Cert `$Cert ``
+        -FilePath `"`$(`$ENV:SystemRoot)\$Script:DSCEncryptionCert`"
+}
 Add-Content ``
     -Path `"`$(`$ENV:SystemRoot)\Setup\Scripts\SetupComplete.log`" ``
     -Value 'Encryption Certificate Imported from CER ...' ``

--- a/src/lib/private/Get-LabUnattendFileContent.ps1
+++ b/src/lib/private/Get-LabUnattendFileContent.ps1
@@ -154,9 +154,6 @@ $unattendContent += @"
             <DisableAutoDaylightTimeSet>false</DisableAutoDaylightTimeSet>
             <TimeZone>$($VM.TimeZone)</TimeZone>
         </component>
-        <component name="Microsoft-Windows-ehome-reg-inf" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="NonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <RestartEnabled>true</RestartEnabled>
-        </component>
         <component name="Microsoft-Windows-ehome-reg-inf" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="NonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RestartEnabled>true</RestartEnabled>
         </component>

--- a/src/lib/private/Get-LabUnattendFileContent.ps1
+++ b/src/lib/private/Get-LabUnattendFileContent.ps1
@@ -133,7 +133,20 @@ function Get-LabUnattendFileContent
 
 "@
 } # If
-$unattendContent += @"
+        if (($VM.Name -like '*7*' -or $VM.Name -like '*2008*') -and $VM.Name -notlike '*10*') {
+            $unattendContent += @"
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+            </OOBE>
+
+"@
+        } else {
+            $unattendContent += @"
             <OOBE>
                 <HideEULAPage>true</HideEULAPage>
                 <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
@@ -144,6 +157,10 @@ $unattendContent += @"
                 <SkipUserOOBE>true</SkipUserOOBE>
                 <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
+
+"@
+} # If
+$unattendContent += @"
             <UserAccounts>
                <AdministratorPassword>
                   <Value>$($VM.AdministratorPassword)</Value>

--- a/src/lib/private/Get-LabUnattendFileContent.ps1
+++ b/src/lib/private/Get-LabUnattendFileContent.ps1
@@ -102,6 +102,7 @@ function Get-LabUnattendFileContent
     </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
 "@
         if ($VM.OSType -eq [LabOSType]::Client)
         {

--- a/src/lib/private/Set-LabDSC.ps1
+++ b/src/lib/private/Set-LabDSC.ps1
@@ -71,6 +71,7 @@ function Set-LabDSC
         } # if
 
         $macAddress = $netAdapter.MacAddress
+        $mac = $macAddress.insert(2,":").insert(5,":").insert(8,":").insert(11,":").insert(14,":")
 
         if (-not $macAddress)
         {
@@ -84,9 +85,13 @@ function Set-LabDSC
         } # If
 
         $dscStartPs += @"
-Get-NetAdapter ``
-    | Where-Object { `$_.MacAddress.Replace('-','') -eq '$macAddress' } ``
-    | Rename-NetAdapter -NewName '$($adapter)'
+if ((Get-WmiObject -Class Win32_OperatingSystem).Version -eq '6.1.7601') {
+    Set-CimInstance -Query "Select * from Win32_NetworkAdapter where MACAddress ='$mac'" -Property @{NetConnectionID="$adapter"}
+} else {
+    Get-NetAdapter ``
+        | Where-Object { `$_.MacAddress.Replace('-','') -eq '$macAddress' } ``
+        | Rename-NetAdapter -NewName '$($adapter)'
+}
 
 "@
     } # Foreach


### PR DESCRIPTION
Hello @PlagueHO - below are some changes that support Windows 7/Server 2008, fixed some minor issues that I introduced in the last round of PR's and added support for Server 2019 Hyper-V configuration version 9.0.

# Bug Fixes
- Fixed minor spacing issue in code that creates Unattend.XML file
- Removed 32-bit Unattend.xml settings (e-home), this was introduced in last PR.

# Improvements / Enhancements
- Modified Unattend.XML to support Windows 7/Server 2008 OS's (Assumes VMs are named 7/2008)
- Modified code that configures Network Adapters to support Windows 7/Server 2008 OS's (since Set-NetAdapter cmdlets aren't available)
- Added support for Server 2019 Host OS/Hyper-V Configuration Versions.