### PR TITLE
Removed use of deprecated Azure DevOps agents - Fixes #384

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,11 @@
     "[markdown]": {
         "files.trimTrailingWhitespace": false,
         "files.encoding": "utf8"
+    },
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Convert build pipeline to use GitTools Azure DevOps extension tasks
   instead of deprecated GitVersion extension.
+- Updated pipeline to use `ubuntu-latest` images for build and deploy stages.
+- Removed automated testing for Windows Server 2016 to eliminate use of
+  deprecated Azure DevOps `ws2016-v2017` agents - fixes [Issue #384](https://github.com/PlagueHO/LabBuilder/issues/384).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,18 @@ The general goals of this module are:
 
 To use this Module you will require on your Lab Host:
 
-1. Operating Systems supported:
+1. Operating Systems supported and automatically tested:
+
+    - Windows Server 2019
+
+1. Operating Systems that should work but are not automatically tested:
 
     - Windows Server 2012
     - Windows Server 2012 R2
     - Windows Server 2016
     - Windows Server 2016, version 1709
     - Windows Server 2016, version 1803
-    - Windows Server 2019
+    - Windows Server 2022
     - Windows 8.0
     - Windows 8.1
     - Windows 10
@@ -89,6 +93,8 @@ To use this Module you will require on your Lab Host:
     but for Windows Server 2012/R2 and Windows 8/8.1 it will need to be
     installed separately._
     _WMF 5.1 can be downloaded from [here](https://www.microsoft.com/en-us/download/details.aspx?id=54616)._
+
+1. **PowerShell Core 6/PowerShell 7**: Untested, but may work.
 
 1. **Hyper-V** available (which requires intel-VT CPU support).
 1. To use labs that contain Nested Hyper-V hosts only Windows 10 built 10586

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ stages:
       - job: Build_Module
         displayName: 'Build Module'
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         steps:
           - task: gittools.gittools.setup-gitversion-task.gitversion/setup@0
             displayName: 'Setup GitVersion'
@@ -51,49 +51,6 @@ stages:
   - stage: Test
     dependsOn: Build
     jobs:
-      - job: Unit_Test_PS_Win2016
-        displayName: 'Unit Test (Powershell 5.1 on Windows Server 2016)'
-        pool:
-          vmImage: vs2017-win2016
-
-        steps:
-          - powershell: |
-              $repositoryOwner,$repositoryName = $env:BUILD_REPOSITORY_NAME -split '/'
-              echo "##vso[task.setvariable variable=RepositoryOwner;isOutput=true]$repositoryOwner"
-              echo "##vso[task.setvariable variable=RepositoryName;isOutput=true]$repositoryName"
-            name: moduleBuildVariable
-            displayName: 'Set Environment Variables'
-
-          - task: DownloadBuildArtifacts@0
-            displayName: 'Download Build Artifact'
-            inputs:
-              buildType: 'current'
-              downloadType: 'single'
-              artifactName: 'output'
-              downloadPath: '$(Build.SourcesDirectory)'
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Unit Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-tasks test -PesterScript 'tests/Unit'"
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: 'output/testResults/NUnit*.xml'
-              testRunTitle: 'Unit (PowerShell 5.1 on Windows Server 2016)'
-
-          - task: PublishCodeCoverageResults@1
-            displayName: 'Publish Code Coverage'
-            condition: succeededOrFailed()
-            inputs:
-              codeCoverageTool: 'JaCoCo'
-              summaryFileLocation: 'output/testResults/CodeCov*.xml'
-              pathToSources: '$(Build.SourcesDirectory)/output/$(moduleBuildVariable.RepositoryName)'
-
       - job: Unit_Test_PS_Win2019
         displayName: 'Unit Test (Powershell 5.1 on Windows Server 2019)'
         pool:
@@ -154,7 +111,7 @@ stages:
       - job: Deploy_Module
         displayName: 'Deploy Module'
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
 
         steps:
           - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
This PR removes the use of deprecated Azure DevOps agents and makes clear what versions of Windows the module is tested with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/labbuilder/385)
<!-- Reviewable:end -->
